### PR TITLE
Fix issue when merging maps.

### DIFF
--- a/wso2-maven-json-merge-plugin/src/main/java/org/wso2/maven/Utils.java
+++ b/wso2-maven-json-merge-plugin/src/main/java/org/wso2/maven/Utils.java
@@ -59,7 +59,7 @@ public class Utils {
             if (returnedValue == null) {
                 baseMap.put(key, value);
             } else if (returnedValue instanceof Map && isChildMergeEnabled) {
-                value = mergeMaps((Map<String, Object>) returnedValue, (Map<String, Object>) value, false);
+                value = mergeMaps((Map<String, Object>) returnedValue, (Map<String, Object>) value, true);
                 baseMap.put(key, value);
             }
         }


### PR DESCRIPTION
## Purpose
> When merging infer.json files with the below structure, it fails.

```
infer_base.json

 "aaa": {
    "bbb": {
      "ccc": true,
      "ddd": true,
    },
  },
```

```
infer_include.json

 "aaa": {
    "bbb": {
      "eee": true,
      "fff": true,
    },
  },
```

Expected:

```
infer_merged.json

 "aaa": {
    "bbb": {
      "ccc": true,
      "ddd": true,
      "eee": true,
      "fff": true,
    },
  },
```
Result:

```
infer_merged.json

 "aaa": {
    "bbb": {
      "ccc": true,
      "ddd": true,
    },
  },
```
