### PR TITLE
Replace File.separator by "/" according to the zip_file_format_specific…

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -173,10 +173,10 @@ public class CARMojo extends AbstractMojo {
             while (true) {
                 if (fileList.length == i) break;
                 if (new File(folder, fileList[i]).isDirectory()) {
-                    zip.putNextEntry(new ZipEntry(fileList[i] + File.separator));
+                    zip.putNextEntry(new ZipEntry(fileList[i] + "/"));
                     zip.closeEntry();
                 }
-                addToZip(Constants.EMPTY_STRING, srcFolder + File.separator + fileList[i], zip);
+                addToZip(Constants.EMPTY_STRING, srcFolder + "/" + fileList[i], zip);
                 i++;
             }
         } catch (IOException ex) {
@@ -203,7 +203,7 @@ public class CARMojo extends AbstractMojo {
                 if (path.trim().equals(Constants.EMPTY_STRING)) {
                     zip.putNextEntry(new ZipEntry(folder.getName()));
                 } else {
-                    zip.putNextEntry(new ZipEntry(path + File.separator + folder.getName()));
+                    zip.putNextEntry(new ZipEntry(path + "/" + folder.getName()));
                 }
                 while ((len = in.read(buf)) > 0) {
                     zip.write(buf, 0, len);
@@ -233,12 +233,12 @@ public class CARMojo extends AbstractMojo {
                 if (fileList.length == i) break;
                 String newPath = folder.getName();
                 if (!path.equalsIgnoreCase(Constants.EMPTY_STRING)) {
-                    newPath = path + File.separator + newPath;
+                    newPath = path + "/" + newPath;
                 }
                 if (new File(folder, fileList[i]).isDirectory()) {
-                    zip.putNextEntry(new ZipEntry(newPath + File.separator + fileList[i] + File.separator));
+                    zip.putNextEntry(new ZipEntry(newPath + "/" + fileList[i] + "/"));
                 }
-                addToZip(newPath, srcFolder + File.separator + fileList[i], zip);
+                addToZip(newPath, srcFolder + "/" + fileList[i], zip);
                 i++;
             }
         } catch (IOException ex) {


### PR DESCRIPTION

Replace File.separator by "/" according to the rule 4.4.17.1 in [zip_file_format_specification](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT). 

4.4.17 file name: (Variable)

       4.4.17.1 The name of the file, with optional relative path.
       The path stored MUST NOT contain a drive or
       device letter, or a leading slash.  All slashes
       MUST be forward slashes '/' as opposed to
       backwards slashes '\' for compatibility with Amiga
       and UNIX file systems etc.  If input came from standard
       input, there is no file name field. 