### PR TITLE
Adding car packaging support

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -100,6 +100,11 @@ public class CARMojo extends AbstractMojo {
 
                 File fileToZip = new File(archiveDirectory);
                 zipFolder(fileToZip.getPath(), getArchiveFile(".car").getPath());
+                File carFile = getArchiveFile(".car");
+                zipFolder(fileToZip.getPath(), carFile.getPath());
+
+                // Attach carFile to Maven context.
+                this.project.getArtifact().setFile(carFile);
 
                 recursiveDelete(fileToZip);
 

--- a/vscode-car-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/vscode-car-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,44 @@
+<component-set>
+  <components>
+    <component>
+      <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+      <role-hint>car</role-hint>
+      <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+      <configuration>
+    <phases>
+      <process-resources>
+        org.apache.maven.plugins:maven-resources-plugin:resources
+      </process-resources>
+<!-- 
+	When the package-element is enabled then we'll run in the package phase automatically. 
+	If the project's pom has an execution-config to execute in the package phase then we'll 
+	be run twice in the same build.... So for now, given the current VSCode plugin generates 
+	this execution-config, this is disabled. Consider to enable to make the plugin-config 
+	inside the project even more lean.
+      <package>
+        org.wso2.maven:vscode-car-plugin:car
+      </package>
+-->
+      <package />
+      <install>
+        org.apache.maven.plugins:maven-install-plugin:install
+      </install>
+      <deploy>
+        org.apache.maven.plugins:maven-deploy-plugin:deploy
+      </deploy>
+    </phases>
+      </configuration>
+    </component>
+    <component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>car</role-hint>
+      <implementation>
+        org.apache.maven.artifact.handler.DefaultArtifactHandler
+      </implementation>
+      <configuration>
+        <type>car</type>
+        <extension>car</extension>
+      </configuration>
+    </component>
+  </components>
+</component-set>


### PR DESCRIPTION
## Purpose
When using the VSCode plugin then the produced pom.xml will generate a Jar and a Car file.
The reason being that there is no packaging specified so jar as default is assumed by maven.
This leads to strange behaviour having multiple artifacts being produced during the build and using other maven goals like maven deploy will take the jar file rather then the car-file (which we want).

A problem seen is that the install phase of maven will actually push the Jar into the mvn-repository and leave the Car. Same for the other maven phases that only handle the Jar and not the Car.

## Goals
This PR contains an improvement where the plugin is extended to enable the 'car' packaging to be used.
This eliminating the (unwanted) jar file creation AND allowing the CAR to become the primary artifact of the project enabling other maven plugins to carry it further.

## Approach
The way to add a custom packaging type is through the registration of the new type through a components.xml. This file is thus added to this plugin.

Then other projects can use this new packaging type by specifying a packaging value in their project. Also, to allow maven to find the new packaging-type the plugin configuration must be enhanced to contain an extensions element.

```
<packaging>car</packaging>
....
<build>
...
<plugin>
   <groupId>org.wso2.maven</groupId>
   <artifactId>vscode-car-plugin</artifactId>
   <version> ****** </version>
   <extensions>true</extensions>
</plugin>
...
```

## Test
To test, build the vscode-car-plugin and amend the pom.xml of an ESB project. Add the packaging element as specified above as well as the extensions-element to the plugin.
Then run mvn clean package and only a CAR file will be produced.
When running mvn clean install its the car file that is published into the mvn-repository.
 