### PR TITLE
Add support to override the Capp name and artifact finalName

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -62,9 +62,15 @@ public class CARMojo extends AbstractMojo {
     /**
      * finalName to use for the generated capp project if the user wants to override the default name
      *
-     * @parameter
+     * @parameter expression="${project.build.finalName}"
      */
     private String finalName;
+
+    /**
+     * CarbonApp name to use for the capp project if the users wants to override the default name
+     * @parameter
+     */
+    private String cAppName;
 
     /**
      * @parameter default-value="${project}"
@@ -91,7 +97,7 @@ public class CARMojo extends AbstractMojo {
                     archiveDirectory);
 
             if (createdArchiveDirectory) {
-                CAppHandler cAppHandler = new CAppHandler();
+                CAppHandler cAppHandler = new CAppHandler(cAppName);
                 List<ArtifactDependency> dependencies = new ArrayList<>();
 
                 cAppHandler.processConfigArtifactXmlFile(projectBaseDir, archiveDirectory, dependencies);

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -39,6 +39,12 @@ class CAppHandler extends AbstractXMLDoc {
     private static final String SYNAPSE_CONFIG_FOLDER = Paths.get("src", "main", "synapse-config").toString();
     private static final String REGISTRY_RESOURCES_FOLDER = Paths.get("src", "main", "registry-resources").toString();
 
+    private String cAppName;
+
+    public CAppHandler(String cAppName) {
+        this.cAppName = cAppName;
+    }
+
     /**
      * Read /synapse-config/artifact.xml file and create corresponding files in archive directory.
      *
@@ -251,7 +257,10 @@ class CAppHandler extends AbstractXMLDoc {
      * @return .car file name
      */
     private String getCAppName(MavenProject project) {
-        return project.getArtifactId() + "CompositeApplication_" + project.getVersion();
+        if (cAppName != null && !cAppName.isEmpty())
+            return cAppName;
+        else
+            return project.getArtifactId() + "CompositeApplication_" + project.getVersion();
     }
 
     @Override


### PR DESCRIPTION
## Purpose
The carbonApp name is comprised of the artifactId concatenated with 'CompositeApplication' and the project-version added to it.
Once the Capp is deployed in EI we see the this name in the Carbon apps list. 

In our current project we use different naming conventions and thus require to be able to change this name.
This PR add the capability to override the CarbonApp name through a property in the plugin configuration and respect the finalName capability of maven.

## Approach
The CARMojo is amended to have the project.build.finalName (default pom element) respected as the CAR filename. If the finalName is not specified in the pom then the current defaults are used. If finalName is specified then its used as car filename.
Also the CARMojo has been given an additional property that allows to override the default cAppName that is determined in the getCAppName method.

## Samples
The following plugin configuration overrides the cAppName to just the artifactId value.
```
 <plugins>
            <plugin>
                <groupId>org.wso2.maven</groupId>
                <artifactId>vscode-car-plugin</artifactId>
                <version>5.2.11-SNAPSHOT</version>
                <extensions>true</extensions>
                <executions>
                        <execution>
                                <phase>package</phase>
                                <goals>
                                        <goal>car</goal>
                                </goals>
                        </execution>
                </executions>
                <configuration>
                        <cAppName>${project.artifactId}</cAppName>
                </configuration>
            </plugin>
       </plugins>
```
