### PR TITLE
Add micro-integrator config-map parser plugin for container projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <module>wso2-synapse-unit-test-plugin</module>
         <module>maven-datasource-plugin</module>
         <module>humantask-maven-plugin</module>
+        <module>wso2-mi-config-mapper</module>
     </modules>
     <build>
         <extensions>
@@ -150,6 +151,41 @@
                 <artifactId>commons-io</artifactId>
                 <version>${org.apache.commons.io.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.hubspot.jinjava</groupId>
+                <artifactId>jinjava</artifactId>
+                <version>${version.jinjava}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.consensys.cava</groupId>
+                <artifactId>cava-toml</artifactId>
+                <version>${version.cava-toml}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${common.logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang.wso2</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${orbit.version.commons.lang}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${version.commons.codec}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.lingala.zip4j</groupId>
+                <artifactId>zip4j</artifactId>
+                <version>${net.lingala.zip4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.config.mapper</groupId>
+                <artifactId>config-mapper</artifactId>
+                <version>${mi.config.mapper.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <properties>
@@ -215,12 +251,23 @@
         <org.wso2.maven.utils.version>5.2.11-SNAPSHOT</org.wso2.maven.utils.version>
         <org.wso2.maven.registry.version>2.1.0</org.wso2.maven.registry.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <gson.version>2.8.2</gson.version>
+        <gson.version>2.8.5</gson.version>
         <testng.version>6.11</testng.version>
         <maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <org.apache.ws.commons.axiom.version>1.2.20</org.apache.ws.commons.axiom.version>
+        <maven.spotbugsplugin.version>3.1.10</maven.spotbugsplugin.version>
+        <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
+        <version.checkstyle>7.8.2</version.checkstyle>
+        <version.jinjava>2.4.14</version.jinjava>
+        <version.cava-toml>0.5.0</version.cava-toml>
+        <orbit.version.commons.io>2.4.0.wso2v1</orbit.version.commons.io>
+        <common.logging.version>1.2</common.logging.version>
+        <orbit.version.commons.lang>2.6.0.wso2v1</orbit.version.commons.lang>
+        <version.commons.codec>1.12</version.commons.codec>
+        <mi.config.mapper.version>1.0.4</mi.config.mapper.version>
+        <net.lingala.zip4j.version>1.3.2</net.lingala.zip4j.version>
     </properties>
 
 </project>

--- a/wso2-mi-config-mapper/pom.xml
+++ b/wso2-mi-config-mapper/pom.xml
@@ -1,0 +1,80 @@
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.11-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>mi-container-config-mapper</artifactId>
+    <packaging>maven-plugin</packaging>
+
+    <name>MI Container Config Mapper Maven Plugin </name>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.config.mapper</groupId>
+            <artifactId>config-mapper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hubspot.jinjava</groupId>
+            <artifactId>jinjava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.consensys.cava</groupId>
+            <artifactId>cava-toml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-mi-config-mapper/src/main/java/org/wso2/config/mapper/ConfigMapParserConstants.java
+++ b/wso2-mi-config-mapper/src/main/java/org/wso2/config/mapper/ConfigMapParserConstants.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.config.mapper;
+
+class ConfigMapParserConstants {
+
+    private ConfigMapParserConstants() {}
+
+    static final String DEPLOYMENT_TOML_PATH = "deployment.toml";
+    static final String PARSER_OUTPUT_PATH = "CarbonHome";
+    static final String DOCKER_FILE = "Dockerfile";
+    static final String METADATA_DIR = ".metadata";
+    static final String CONF_DIR = ".metadata";
+    static final String RESOURCES_PATH = "resources";
+    static final String TEMPLATES_ZIP_FILE = "templates.zip";
+    static final String METADATA_CONFIG_PROPERTIES_FILE = "metadata_config.properties";
+    static final String TEMPLATES_URL = "http://product-dist.wso2.com/p2/templates/";
+
+    static final String DOCKER_MI_DIR_PATH = " /home/wso2carbon/wso2mi/";
+    static final String DOCKER_FROM_TAG = "FROM wso2/micro-integrator";
+    static final String DOCKER_COMPOSITE_COPY_TAG = "COPY CompositeApps";
+    static final String DOCKER_LIBS_COPY_TAG = "COPY Libs";
+    static final String DOCKER_ENV_TAG = "ENV ";
+    static final String METADATA_DIR_PATH = DOCKER_MI_DIR_PATH + "repository/resources/conf/.metadata";
+    static final String DOCKER_COPY_FILE = "COPY  --chown=wso2carbon:wso2 ";
+    static final String DOCKER_MAKE_DIR = "RUN mkdir";
+}

--- a/wso2-mi-config-mapper/src/main/java/org/wso2/config/mapper/ConfigMapParserMojo.java
+++ b/wso2-mi-config-mapper/src/main/java/org/wso2/config/mapper/ConfigMapParserMojo.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.config.mapper;
+
+import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.wso2.config.mapper.model.Context;
+import org.wso2.config.mapper.util.FileUtils;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+@Mojo(name = "config-mapper-parser")
+public class ConfigMapParserMojo extends AbstractMojo {
+
+    @Parameter(property = "miVersion")
+    private String miVersion;
+
+    /**
+     * Execution method of Mojo class.
+     *
+     * @throws MojoExecutionException if error occurred while running the plugin
+     */
+    public void execute() throws MojoExecutionException {
+        try {
+            //download templates folder to the resource folder
+            boolean isDownloaded = downloadTemplates();
+            if (!isDownloaded) {
+                return;
+            }
+
+            String templatePath = ConfigMapParserConstants.RESOURCES_PATH + File.separator + "templates";
+            File deplymentTomlFile = new File(ConfigMapParserConstants.DEPLOYMENT_TOML_PATH);
+            boolean isDeploymentTomlFileExist = deplymentTomlFile.exists();
+
+            File templateDirectory = new File(templatePath);
+            boolean isTemplateDirectoryExist = templateDirectory.exists();
+
+            boolean isParsedSuccessfully = false;
+            if (isDeploymentTomlFileExist && isTemplateDirectoryExist) {
+                getLog().info("ConfigParser for deployment.toml file has been started");
+                runConfigMapParser(deplymentTomlFile, templatePath);
+                isParsedSuccessfully = true;
+                getLog().info("ConfigParser successfully parsed the deployment.toml file");
+            } else {
+                getLog().warn("Required files not found for the Config Parser: deployment.toml " +
+                        "file or template files");
+            }
+
+            //append output files to the Dockerfile
+            if (isParsedSuccessfully) {
+                List<String> parsedOutputFileList = new ArrayList<>();
+                listFilesForFolder(new File(ConfigMapParserConstants.PARSER_OUTPUT_PATH), parsedOutputFileList);
+                updateDockerFile(parsedOutputFileList);
+                getLog().info("Dockerfile successfully updated with the config files");
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("Exception while parsing the deployment.toml file \n" + e);
+        }
+    }
+
+    /**
+     * Download templates files from host and added to the resources.
+     *
+     * @return templates successfully downloaded or not
+     * @throws ZipException while extracting the zip file
+     * @throws ConfigParserException while clearing the resources directory
+     */
+    private boolean downloadTemplates() throws ConfigParserException, ZipException {
+        boolean isDownloaded = true;
+        String sourceURL = ConfigMapParserConstants.TEMPLATES_URL + miVersion + "/" +
+                ConfigMapParserConstants.TEMPLATES_ZIP_FILE;
+
+        //clear the resources directory
+        FileUtils.deleteDirectory(new File(ConfigMapParserConstants.RESOURCES_PATH));
+        File tempFile = new File(ConfigMapParserConstants.RESOURCES_PATH);
+        if (!tempFile.mkdirs()) {
+            return false;
+        }
+
+        try (InputStream inputStream = new URL(sourceURL).openStream()) {
+            if (inputStream.available() == 0) {
+                isDownloaded = false;
+            } else {
+                String templateZipLocation = ConfigMapParserConstants.RESOURCES_PATH + File.separator
+                        + ConfigMapParserConstants.TEMPLATES_ZIP_FILE;
+                Files.copy(inputStream, Paths.get(templateZipLocation));
+                ZipFile zipFile = new ZipFile(templateZipLocation);
+                zipFile.extractAll(ConfigMapParserConstants.RESOURCES_PATH);
+
+                File templateZipFile = new File(templateZipLocation);
+                if (!templateZipFile.delete()) {
+                    getLog().warn("Templates zip file can not delete from the resource path");
+                }
+            }
+        } catch (IOException e) {
+            isDownloaded = false;
+            getLog().error("Error while downloading the templates for config mapper", e);
+        }
+
+        return isDownloaded;
+    }
+
+    /**
+     * Append the list of parsed files to the Dockerfile.
+     *
+     * @param deploymentToml deployment toml file
+     * @param templatePath path for the template files
+     * @throws ConfigParserException while parsing the configurations
+     * @throws IOException while parsing the IO operations
+     */
+    private void runConfigMapParser(File deploymentToml, String templatePath) throws ConfigParserException, IOException {
+        Context context = new Context();
+        ConfigParser.ConfigPaths.setPaths(ConfigMapParserConstants.DEPLOYMENT_TOML_PATH, templatePath,
+                ConfigMapParserConstants.PARSER_OUTPUT_PATH);
+        Map<String,String> configMap = ConfigParser.parse(context);
+        Map<String,String> metaDataMap = new HashMap<>();
+
+        //clear the CarbonHome directory
+        FileUtils.deleteDirectory(new File(ConfigMapParserConstants.PARSER_OUTPUT_PATH));
+
+        for (Map.Entry<String,String> entry : configMap.entrySet()) {
+            String fileSource = entry.getValue();
+            String filePath = entry.getKey();
+            String fileFromOutput = ConfigMapParserConstants.PARSER_OUTPUT_PATH + File.separator + filePath;
+
+            File tempFile = new File(fileFromOutput);
+            tempFile.getParentFile().mkdirs();
+            tempFile.createNewFile();
+            Files.write(Paths.get(fileFromOutput), fileSource.getBytes());
+            metaDataMap.put(filePath, DigestUtils.md5Hex(entry.getValue()));
+        }
+
+        //add deployment.toml file md5Hex to the metaDataMap
+        String tomlFileSource = new String(Files.readAllBytes(Paths.get(ConfigMapParserConstants.DEPLOYMENT_TOML_PATH)),
+                StandardCharsets.UTF_8);
+        String tomlOutputPath = ConfigMapParserConstants.CONF_DIR + File.separator
+                + ConfigMapParserConstants.DEPLOYMENT_TOML_PATH;
+        metaDataMap.put(tomlOutputPath, DigestUtils.md5Hex(tomlFileSource));
+
+        //copy deployment.toml file to the CarbonHome/conf directory
+        String confDirPath = ConfigMapParserConstants.PARSER_OUTPUT_PATH + File.separator
+                + ConfigMapParserConstants.CONF_DIR + File.separator + ConfigMapParserConstants.DEPLOYMENT_TOML_PATH;
+        File destinationFile = new File(confDirPath);
+        Files.copy(deploymentToml.toPath(), destinationFile.toPath());
+
+        //create and copy .metadata folder to CarbonHome
+        generateMetadataFolder(metaDataMap);
+    }
+
+    /**
+     * Generate .metadata_config.properties file and set properties.
+     *
+     * @param metaDataMap parser generated metadata map
+     * @throws IOException while writing to the metadata_template.properties
+     */
+    private void generateMetadataFolder(Map<String,String> metaDataMap) throws IOException {
+        String templateFilePath = ConfigMapParserConstants.PARSER_OUTPUT_PATH + File.separator
+                + ConfigMapParserConstants.METADATA_DIR + File.separator
+                + ConfigMapParserConstants.METADATA_CONFIG_PROPERTIES_FILE;
+
+        //create the metadata_config.properties
+        File tempFile = new File(templateFilePath);
+        if (!tempFile.getParentFile().mkdirs() || !tempFile.createNewFile()) {
+            throw new IOException("Creating .metadata directory in " + ConfigMapParserConstants.PARSER_OUTPUT_PATH
+                    + " path failed");
+        }
+
+        try (OutputStream output = new FileOutputStream(templateFilePath)) {
+            Properties prop = new Properties();
+
+            // set the properties value
+            for (Map.Entry<String,String> entry : metaDataMap.entrySet()) {
+                prop.setProperty(entry.getKey(), entry.getValue());
+            }
+
+            // save properties to project root folder
+            prop.store(output, null);
+
+        } catch (IOException e) {
+            throw new IOException("Exception while writing to the "
+                    + ConfigMapParserConstants.METADATA_CONFIG_PROPERTIES_FILE + "\n" + e);
+        }
+    }
+
+    /**
+     * Append the list of parsed files to the Dockerfile.
+     *
+     * @param parsedOutputFileList list of parsed files
+     * @throws IOException while writing to the Dockerfile
+     */
+    private void updateDockerFile(List<String> parsedOutputFileList) throws IOException {
+        String dockerFileBaseEntries = getBaseImageInDockerfile();
+        StringBuilder builder = new StringBuilder(dockerFileBaseEntries);
+
+        for (String filePath : parsedOutputFileList) {
+            String[] filePathSeparateList = filePath.split(File.separator);
+            StringBuilder innerBuilder = new StringBuilder();
+            for (int x = 1; x < filePathSeparateList.length - 1 ; x++) {
+                innerBuilder.append(filePathSeparateList[x]).append("/");
+            }
+            innerBuilder.append(filePathSeparateList[filePathSeparateList.length - 1]);
+            builder.append(ConfigMapParserConstants.DOCKER_COPY_FILE).append(filePath)
+                    .append(ConfigMapParserConstants.DOCKER_MI_DIR_PATH).append(innerBuilder.toString());
+            builder.append(System.lineSeparator());
+        }
+
+        //copy .metadata folder to the repository/resources/conf directory
+        builder.append(ConfigMapParserConstants.DOCKER_MAKE_DIR + ConfigMapParserConstants.METADATA_DIR_PATH);
+        builder.append(System.lineSeparator());
+        builder.append(ConfigMapParserConstants.DOCKER_COPY_FILE).append(ConfigMapParserConstants.PARSER_OUTPUT_PATH)
+                .append(File.separator).append(ConfigMapParserConstants.METADATA_DIR).append(File.separator)
+                .append(ConfigMapParserConstants.METADATA_CONFIG_PROPERTIES_FILE)
+                .append(ConfigMapParserConstants.METADATA_DIR_PATH);
+
+        try (InputStream inputStream = new ByteArrayInputStream(builder.toString()
+                .getBytes(StandardCharsets.UTF_8));
+             OutputStream outputStream = new FileOutputStream(new File(ConfigMapParserConstants.DOCKER_FILE))) {
+             IOUtils.copy(inputStream, outputStream);
+        } catch (IOException e) {
+            throw new IOException("Exception while writing to the Dockerfile \n" + e);
+        }
+    }
+
+    /**
+     * List down the files which inside a diractory.
+     *
+     * @param folder folder as a File
+     * @param outputList list for store outputs
+     */
+    private void listFilesForFolder(final File folder, List<String> outputList) {
+        File[] listOfFiles = folder.listFiles();
+        if (listOfFiles != null) {
+            for (final File fileEntry : listOfFiles) {
+                if (fileEntry.isDirectory()) {
+                    listFilesForFolder(fileEntry, outputList);
+                } else if (fileEntry.isFile() && !fileEntry.isHidden()) {
+                    outputList.add(fileEntry.getPath());
+                }
+            }
+        }
+    }
+
+    /**
+     * Get default/initial lines from Dockerfile.
+     *
+     * @return default Dockerfile entries
+     * @throws IOException exception while reading dockerfile
+     */
+    private String getBaseImageInDockerfile() throws IOException {
+        StringBuilder builder = new StringBuilder();
+        try (BufferedReader bufferReader = new BufferedReader(new FileReader(ConfigMapParserConstants.DOCKER_FILE))) {
+            String currentLine;
+            while ((currentLine = bufferReader.readLine()) != null) {
+                if (currentLine.contains(ConfigMapParserConstants.DOCKER_FROM_TAG) ||
+                        currentLine.contains(ConfigMapParserConstants.DOCKER_COMPOSITE_COPY_TAG) ||
+                        currentLine.contains(ConfigMapParserConstants.DOCKER_LIBS_COPY_TAG) ||
+                        currentLine.contains(ConfigMapParserConstants.DOCKER_ENV_TAG)) {
+                    builder.append(currentLine).append(System.lineSeparator());
+                }
+            }
+        } catch (IOException e) {
+            throw new IOException("Exception while writing to the Dockerfile \n" + e);
+        }
+
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
## Purpose
> Adding maven plugin for the container projects created via the integration studio which can execute the deployment.toml file with the relevant templates files and generates the configurations for the containers. Also it capable to update the Dockerfile with the generated configuration file COPY commands. 
