### PR TITLE
Define package phase in components.xml in vscode-car-plugin

### DIFF
--- a/org.wso2.maven.utils/src/main/java/org/wso2/developerstudio/eclipse/utils/file/FileUtils.java
+++ b/org.wso2.maven.utils/src/main/java/org/wso2/developerstudio/eclipse/utils/file/FileUtils.java
@@ -157,7 +157,7 @@ public class FileUtils{
 		return success;  
 	}
 
-	public static boolean createDirectorys(String directory){
+	public static boolean createDirectories(String directory){
 		// Create a directory; all ancestor directories must exist
 		boolean success = (new File(directory)).mkdirs();
 		if (!success) {

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -87,7 +87,7 @@ public class CARMojo extends AbstractMojo {
         try {
             // Create directory to be compressed.
             String archiveDirectory = getArchiveFile(Constants.EMPTY_STRING).getAbsolutePath();
-            boolean createdArchiveDirectory = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createDirectory(
+            boolean createdArchiveDirectory = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createDirectories(
                     archiveDirectory);
 
             if (createdArchiveDirectory) {
@@ -99,7 +99,6 @@ public class CARMojo extends AbstractMojo {
                 cAppHandler.createDependencyArtifactsXmlFile(archiveDirectory, dependencies, project);
 
                 File fileToZip = new File(archiveDirectory);
-                zipFolder(fileToZip.getPath(), getArchiveFile(".car").getPath());
                 File carFile = getArchiveFile(".car");
                 zipFolder(fileToZip.getPath(), carFile.getPath());
 

--- a/vscode-car-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/vscode-car-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,44 +1,54 @@
+<!--
+  ~ Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
 <component-set>
-  <components>
-    <component>
-      <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
-      <role-hint>car</role-hint>
-      <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
-      <configuration>
-    <phases>
-      <process-resources>
-        org.apache.maven.plugins:maven-resources-plugin:resources
-      </process-resources>
-<!-- 
-	When the package-element is enabled then we'll run in the package phase automatically. 
-	If the project's pom has an execution-config to execute in the package phase then we'll 
-	be run twice in the same build.... So for now, given the current VSCode plugin generates 
-	this execution-config, this is disabled. Consider to enable to make the plugin-config 
-	inside the project even more lean.
-      <package>
-        org.wso2.maven:vscode-car-plugin:car
-      </package>
--->
-      <package />
-      <install>
-        org.apache.maven.plugins:maven-install-plugin:install
-      </install>
-      <deploy>
-        org.apache.maven.plugins:maven-deploy-plugin:deploy
-      </deploy>
-    </phases>
-      </configuration>
-    </component>
-    <component>
-      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
-      <role-hint>car</role-hint>
-      <implementation>
-        org.apache.maven.artifact.handler.DefaultArtifactHandler
-      </implementation>
-      <configuration>
-        <type>car</type>
-        <extension>car</extension>
-      </configuration>
-    </component>
-  </components>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>car</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <phases>
+                    <process-resources>
+                        org.apache.maven.plugins:maven-resources-plugin:resources
+                    </process-resources>
+                    <package>
+                        org.wso2.maven:vscode-car-plugin:car
+                    </package>
+                    <install>
+                        org.apache.maven.plugins:maven-install-plugin:install
+                    </install>
+                    <deploy>
+                        org.apache.maven.plugins:maven-deploy-plugin:deploy
+                    </deploy>
+                </phases>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>car</role-hint>
+            <implementation>
+                org.apache.maven.artifact.handler.DefaultArtifactHandler
+            </implementation>
+            <configuration>
+                <type>car</type>
+                <extension>car</extension>
+            </configuration>
+        </component>
+    </components>
 </component-set>


### PR DESCRIPTION
## Purpose
Defining package phase in components.xml as follows will no longer require the package phase to be defined in the project's pom.xml file.

```
<package>
   org.wso2.maven:vscode-car-plugin:car
</package>
```

With the above fix, vscode-car-plugin configuration will be as follows,

```
<plugin>
      <groupId>org.wso2.maven</groupId>
      <artifactId>vscode-car-plugin</artifactId>
      <version>********</version>
      <extensions>true</extensions>
</plugin>
```