### PR TITLE
Refactor cAppName and archiveName parameters in vscode-car-plugin

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -46,28 +46,29 @@ import org.wso2.maven.Model.ArtifactDependency;
 public class CARMojo extends AbstractMojo {
 
     /**
-     * Location archiveLocation folder
+     * Location archiveLocation folder.
      *
      * @parameter expression="${project.basedir}"
      */
     private File projectBaseDir;
 
     /**
-     * Location archiveLocation folder
+     * Location archiveLocation folder.
      *
      * @parameter expression="${project.build.directory}"
      */
     private File archiveLocation;
 
     /**
-     * finalName to use for the generated capp project if the user wants to override the default name
+     * archiveName is used if the user wants to override the default name of the generated archive with .car extension.
      *
-     * @parameter expression="${project.build.finalName}"
+     * @parameter expression="${project.build.archiveName}"
      */
-    private String finalName;
+    private String archiveName;
 
     /**
-     * CarbonApp name to use for the capp project if the users wants to override the default name
+     * CarbonApp is used if the user wants to override the default name of the carbon application.
+     *
      * @parameter
      */
     private String cAppName;
@@ -78,7 +79,7 @@ public class CARMojo extends AbstractMojo {
     private MavenProject project;
 
     /**
-     * A classifier for the build final name
+     * A classifier for the build final name.
      *
      * @parameter
      */
@@ -138,8 +139,8 @@ public class CARMojo extends AbstractMojo {
      */
     private File getArchiveFile(String fileExtension) {
         File archiveFile;
-        if (finalName != null && !finalName.trim().equals(Constants.EMPTY_STRING)) {
-            archiveFile = new File(archiveLocation, finalName + fileExtension);
+        if (archiveName != null && !archiveName.trim().equals(Constants.EMPTY_STRING)) {
+            archiveFile = new File(archiveLocation, archiveName + fileExtension);
             return archiveFile;
         }
         String archiveFilename = project.getArtifactId() + "_" + project.getVersion() +

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -260,7 +260,7 @@ class CAppHandler extends AbstractXMLDoc {
         if (cAppName != null && !cAppName.isEmpty())
             return cAppName;
         else
-            return project.getArtifactId() + "CompositeApplication_" + project.getVersion();
+            return project.getArtifactId() + "CompositeApplication";
     }
 
     @Override


### PR DESCRIPTION
## Purpose
- Earlier, if the user does not provide a name for the target cAppName, the default name was generated as `project.getArtifactId() + "CompositeApplication_" + project.getVersion()`. Here, project refers to the ESB project. This PR changes it to `project.getArtifactId() + "CompositeApplication"` which is the same convention as in maven-car-plugin.

- Rename finalName parameter as archiveName which is used if the user wants to override the default name of the generated archive with .car extension.

Related PR: https://github.com/wso2/maven-tools/pull/43