### PR TITLE
Added Resource filtering support

### DIFF
--- a/vscode-car-plugin/pom.xml
+++ b/vscode-car-plugin/pom.xml
@@ -53,6 +53,11 @@
             <version>${org.apache.maven.plugin.api.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-filtering</artifactId>
+            <version>${maven-filtering.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
@@ -82,5 +87,6 @@
     </dependencies>
     <properties>
         <org.apache.ws.commons.axiom.version>1.2.20</org.apache.ws.commons.axiom.version>
+        <maven-filtering.version>3.1.1</maven-filtering.version>
     </properties>
 </project>

--- a/vscode-car-plugin/pom.xml
+++ b/vscode-car-plugin/pom.xml
@@ -53,11 +53,6 @@
             <version>${org.apache.maven.plugin.api.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-filtering</artifactId>
-            <version>${maven-filtering.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
@@ -87,6 +82,5 @@
     </dependencies>
     <properties>
         <org.apache.ws.commons.axiom.version>1.2.20</org.apache.ws.commons.axiom.version>
-        <maven-filtering.version>3.1.1</maven-filtering.version>
     </properties>
 </project>

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -101,8 +101,8 @@ public class CARMojo extends AbstractMojo {
                 CAppHandler cAppHandler = new CAppHandler(cAppName);
                 List<ArtifactDependency> dependencies = new ArrayList<>();
 
-                cAppHandler.processConfigArtifactXmlFile(projectBaseDir, archiveDirectory, dependencies);
-                cAppHandler.processRegistryResourceArtifactXmlFile(projectBaseDir, archiveDirectory, dependencies);
+                cAppHandler.processConfigArtifactXmlFile(archiveLocation, archiveDirectory, dependencies);
+                cAppHandler.processRegistryResourceArtifactXmlFile(archiveLocation, archiveDirectory, dependencies);
                 cAppHandler.createDependencyArtifactsXmlFile(archiveDirectory, dependencies, project);
 
                 File fileToZip = new File(archiveDirectory);

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -22,32 +22,18 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import javax.xml.stream.XMLStreamException;
 
-import com.google.inject.internal.util.Lists;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.filtering.MavenFilteringException;
-import org.apache.maven.shared.filtering.MavenResourcesExecution;
-import org.apache.maven.shared.filtering.MavenResourcesFiltering;
-import org.codehaus.plexus.component.annotations.Requirement;
 import org.wso2.maven.Model.ArchiveException;
 import org.wso2.maven.Model.ArtifactDependency;
-
-import static org.wso2.maven.CAppHandler.REGISTRY_RESOURCES_FOLDER;
-import static org.wso2.maven.CAppHandler.SYNAPSE_CONFIG_FOLDER;
 
 
 /**
@@ -58,7 +44,6 @@ import static org.wso2.maven.CAppHandler.SYNAPSE_CONFIG_FOLDER;
  */
 @Mojo(name = "WSO2ESBDeployableArchive")
 public class CARMojo extends AbstractMojo {
-    private static final List<String> EMPTY_LIST = Collections.unmodifiableList(Lists.<String>newArrayList());
 
     /**
      * Location archiveLocation folder.
@@ -101,26 +86,6 @@ public class CARMojo extends AbstractMojo {
     private String classifier;
 
     /**
-     * Source encoding for this project.
-     *
-     * @parameter expression="${project.build.sourceEncoding}"
-     */
-    private String sourceEncoding;
-
-    /**
-     * the current maven session instance.
-     *
-     * @parameter expression="${session}"
-     */
-    protected MavenSession session;
-
-    /**
-     * a filtering capability is needed to filter project-resources
-     */
-    @Component
-    private MavenResourcesFiltering mavenResourcesFiltering;
-
-    /**
      * Read artifact.xml files and create .car file.
      */
     public void execute() throws MojoExecutionException {
@@ -128,64 +93,32 @@ public class CARMojo extends AbstractMojo {
         // Create CApp
         try {
             // Create directory to be compressed.
-            String archiveWorkDirectory = getArchiveFile(Constants.EMPTY_STRING).getAbsolutePath();
-            boolean createdArchiveDirectory = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createDirectories(archiveWorkDirectory);
+            String archiveDirectory = getArchiveFile(Constants.EMPTY_STRING).getAbsolutePath();
+            boolean createdArchiveDirectory = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createDirectories(
+                    archiveDirectory);
 
             if (createdArchiveDirectory) {
                 CAppHandler cAppHandler = new CAppHandler(cAppName);
                 List<ArtifactDependency> dependencies = new ArrayList<>();
 
-                // filter synapse-config files into the archiveWorkDirectory
-                filterResources(Paths.get(projectBaseDir.getAbsolutePath(), SYNAPSE_CONFIG_FOLDER), Paths.get(archiveWorkDirectory, SYNAPSE_CONFIG_FOLDER).toFile());
-                // filter registry-resources files into the archiveWorkDirectory
-                filterResources(Paths.get(projectBaseDir.getAbsolutePath(), REGISTRY_RESOURCES_FOLDER), Paths.get(archiveWorkDirectory, REGISTRY_RESOURCES_FOLDER).toFile());
+                cAppHandler.processConfigArtifactXmlFile(projectBaseDir, archiveDirectory, dependencies);
+                cAppHandler.processRegistryResourceArtifactXmlFile(projectBaseDir, archiveDirectory, dependencies);
+                cAppHandler.createDependencyArtifactsXmlFile(archiveDirectory, dependencies, project);
 
-                // Make sure we continue our work using the archiveWorkDirectory
-                File filteredProjectBaseDir = Paths.get(archiveWorkDirectory).toFile();
-
-                String cappArchiveDirectory = Paths.get(this.project.getBuild().getOutputDirectory(), "capp").toString();
-                cAppHandler.processConfigArtifactXmlFile(filteredProjectBaseDir, cappArchiveDirectory, dependencies);
-                cAppHandler.processRegistryResourceArtifactXmlFile(filteredProjectBaseDir, cappArchiveDirectory, dependencies);
-                cAppHandler.createDependencyArtifactsXmlFile(cappArchiveDirectory, dependencies, project);
-
-                File fileToZip = new File(cappArchiveDirectory);
+                File fileToZip = new File(archiveDirectory);
                 File carFile = getArchiveFile(".car");
                 zipFolder(fileToZip.getPath(), carFile.getPath());
 
                 // Attach carFile to Maven context.
                 this.project.getArtifact().setFile(carFile);
 
-                // Delete the filtered files folder
                 recursiveDelete(fileToZip);
-                // Delete temp archive folder
-                recursiveDelete(filteredProjectBaseDir);
 
             } else {
                 getLog().error("Could not create corresponding archive directory.");
             }
         } catch (XMLStreamException | IOException | ArchiveException e) {
             getLog().error(e);
-        }
-    }
-
-    /**
-     * Filter the resources in given sourcePath, output the results to the outputFolder
-     * @param sourcePath folder containing resources
-     * @param outputFolder location where filtered resources will be stored
-     * @throws MojoExecutionException if filtering throws an exception its wrapped in this MojoExecutionException for clean handling by Maven.
-     */
-    private void filterResources(Path sourcePath, File outputFolder) throws MojoExecutionException {
-        Resource srcResource = new Resource();
-        srcResource.setDirectory(sourcePath.toString());
-        srcResource.setFiltering(true);
-
-        MavenResourcesExecution execution = new MavenResourcesExecution(Collections.singletonList(srcResource), outputFolder, this.project, sourceEncoding, EMPTY_LIST, EMPTY_LIST, session);
-        execution.setUseDefaultFilterWrappers(true);
-
-        try {
-            mavenResourcesFiltering.filterResources(execution);
-        } catch (MavenFilteringException e) {
-            throw new MojoExecutionException("Error while filtering project resources", e);
         }
     }
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -36,8 +36,8 @@ import org.wso2.maven.core.model.AbstractXMLDoc;
 
 class CAppHandler extends AbstractXMLDoc {
 
-    private static final String SYNAPSE_CONFIG_FOLDER = Paths.get("src", "main", "synapse-config").toString();
-    private static final String REGISTRY_RESOURCES_FOLDER = Paths.get("src", "main", "registry-resources").toString();
+    protected static final String SYNAPSE_CONFIG_FOLDER = Paths.get("src", "main", "synapse-config").toString();
+    protected static final String REGISTRY_RESOURCES_FOLDER = Paths.get("src", "main", "registry-resources").toString();
 
     private String cAppName;
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -36,8 +36,8 @@ import org.wso2.maven.core.model.AbstractXMLDoc;
 
 class CAppHandler extends AbstractXMLDoc {
 
-    private static final String SYNAPSE_CONFIG_FOLDER = Paths.get("src", "main", "synapse-config").toString();
-    private static final String REGISTRY_RESOURCES_FOLDER = Paths.get("src", "main", "registry-resources").toString();
+    private static final String SYNAPSE_CONFIG_FOLDER = Paths.get("classes","main", "synapse-config").toString();
+    private static final String REGISTRY_RESOURCES_FOLDER = Paths.get("classes", "main", "registry-resources").toString();
 
     private String cAppName;
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -36,8 +36,8 @@ import org.wso2.maven.core.model.AbstractXMLDoc;
 
 class CAppHandler extends AbstractXMLDoc {
 
-    protected static final String SYNAPSE_CONFIG_FOLDER = Paths.get("src", "main", "synapse-config").toString();
-    protected static final String REGISTRY_RESOURCES_FOLDER = Paths.get("src", "main", "registry-resources").toString();
+    private static final String SYNAPSE_CONFIG_FOLDER = Paths.get("src", "main", "synapse-config").toString();
+    private static final String REGISTRY_RESOURCES_FOLDER = Paths.get("src", "main", "registry-resources").toString();
 
     private String cAppName;
 


### PR DESCRIPTION
This is a PR for issue https://github.com/wso2/maven-tools/issues/64

## Approach
By pulling in the maven shared component 'maven-filtering' we can call a filtering component to perform property-placeholder filtering.
No changes are necessary to the plugin definition as both the files in the src/main/synapse-config as well as the src/main/registry-resource folders are automatically added to the scope of the resource filtering.

