### PR TITLE
Add cipherTool execution for config-mapper plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <version.commons.codec>1.12</version.commons.codec>
         <mi.config.mapper.version>1.0.7</mi.config.mapper.version>
         <net.lingala.zip4j.version>1.3.2</net.lingala.zip4j.version>
-        <org.wso2.ciphertool.version>1.1.13-SNAPSHOT</org.wso2.ciphertool.version>
+        <org.wso2.ciphertool.version>1.1.13</org.wso2.ciphertool.version>
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,11 @@
                 <artifactId>config-mapper</artifactId>
                 <version>${mi.config.mapper.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.ciphertool</groupId>
+                <artifactId>org.wso2.ciphertool</artifactId>
+                <version>${org.wso2.ciphertool.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <properties>
@@ -268,6 +273,7 @@
         <version.commons.codec>1.12</version.commons.codec>
         <mi.config.mapper.version>1.0.7</mi.config.mapper.version>
         <net.lingala.zip4j.version>1.3.2</net.lingala.zip4j.version>
+        <org.wso2.ciphertool.version>1.1.13-SNAPSHOT</org.wso2.ciphertool.version>
     </properties>
 
 </project>

--- a/wso2-mi-config-mapper/pom.xml
+++ b/wso2-mi-config-mapper/pom.xml
@@ -75,5 +75,10 @@
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.wso2.ciphertool/org.wso2.ciphertool -->
+        <dependency>
+            <groupId>org.wso2.ciphertool</groupId>
+            <artifactId>org.wso2.ciphertool</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/wso2-mi-config-mapper/src/main/java/org/wso2/config/mapper/ConfigMapParserConstants.java
+++ b/wso2-mi-config-mapper/src/main/java/org/wso2/config/mapper/ConfigMapParserConstants.java
@@ -39,4 +39,21 @@ class ConfigMapParserConstants {
     static final String METADATA_DIR_PATH = DOCKER_MI_DIR_PATH + "repository/resources/conf/.metadata";
     static final String DOCKER_COPY_FILE = "COPY  --chown=wso2carbon:wso2 ";
     static final String DOCKER_MAKE_DIR = "RUN mkdir";
+
+    public static final String SECRET_PROPERTY_MAP_NAME = "secrets";
+    public static final String RESOURCE_DIR_PATH = "Resources";
+    public static final String SECURITY_DIR_PATH = "security";
+    public static final String SECRET_CONF_FILE_NAME = "secret-conf.properties";
+    // system properties related to cipher tool
+    public static final String KEY_LOCATION_PROPERTY = "primary.key.location";
+    public static final String KEY_TYPE_PROPERTY = "primary.key.type";
+    public static final String KEY_ALIAS_PROPERTY = "primary.key.alias";
+    public static final String KEYSTORE_PASSWORD = "keystore.password";
+    public static final String SECRET_PROPERTY_FILE_PROPERTY = "secret.conf.properties.file";
+    public static final String SECRET_FILE_LOCATION = "secretRepositories.file.location";
+    public static final String DEPLOYMENT_CONFIG_FILE_PATH = "deployment.config.file.path";
+    public static final String SECRET_CONF_KEYSTORE_LOCATION_PROPERTY = "keystore.identity.location";
+    // password-tmp file name
+    public static final String PASSWORD_TMP_FILE_NAME = "password-tmp";
+
 }


### PR DESCRIPTION
# Purpose
> This will run the cipherTool if secrets are defined in the deployment.toml
plugin configuration will be updated as follows in docker projects.
```
  <properties>
    <keystore.password>wso2carbon</keystore.password>
    <keystore.name>wso2carbon.jks</keystore.name>
    <keystore.type>JKS</keystore.type>
    <keystore.alias>wso2carbon</keystore.alias>
  </properties>

      <plugin>
        <groupId>org.wso2.maven</groupId>
        <artifactId>mi-container-config-mapper</artifactId>
        <version>5.2.23-SNAPSHOT</version>
        <extensions>true</extensions>
        <executions>
          <execution>
            <id>config-mapper-parser</id>
            <phase>package</phase>
            <goals>
              <goal>config-mapper-parser</goal>
            </goals>
            <configuration>
              <miVersion>1.1.0</miVersion>
              <keystoreName>${keystore.name}</keystoreName>
              <keystoreAlias>${keystore.alias}</keystoreAlias>
              <keystoreType>${keystore.type}</keystoreType>
              <keystorePassword>${keystore.password}</keystorePassword>
            </configuration>
          </execution>
        </executions>
        <configuration/>
      </plugin>
```

- Will only run if and only if a [secrets] section is defined in the deployment.toml
- keystore should be available in the Resources directory if the project.
- Plugin will copy secret-conf.properties and password-tmp files into the image 

