### PR TITLE
Adding capability to run with with maven multi module projects

### DIFF
--- a/wso2-mi-config-mapper/src/main/java/org/wso2/config/mapper/ConfigMapParserConstants.java
+++ b/wso2-mi-config-mapper/src/main/java/org/wso2/config/mapper/ConfigMapParserConstants.java
@@ -31,6 +31,7 @@ class ConfigMapParserConstants {
     static final String TEMPLATES_ZIP_FILE = "templates.zip";
     static final String PATH_SEPARATOR = "/";
     static final String METADATA_CONFIG_PROPERTIES_FILE = "metadata_config.properties";
+    static final String REFERENCES_PROPERTIES_FILE = "references.properties";
     static final String TEMPLATES_URL = "http://product-dist.wso2.com/p2/templates/";
 
     static final String DOCKER_MI_DIR_PATH = " ${WSO2_SERVER_HOME}/";


### PR DESCRIPTION
## Purpose
> $subject. Previously, the config-mapper plugin did not run with the MMM projects due to the relative paths of the resources. 