### PR TITLE
Add serverType property to distinguish MI or EI server

### DIFF
--- a/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/CAppHandler.java
+++ b/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/CAppHandler.java
@@ -1,0 +1,54 @@
+/*
+ *
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.maven.car.artifact;
+
+import org.apache.maven.project.MavenProject;
+
+import java.io.File;
+
+/**
+ * This class provides an interface for all CApp handlers.
+ */
+public interface CAppHandler {
+
+    /**
+     * Executes the CApp deploy logic relevant to the handler.
+     *
+     * @param username  Username
+     * @param password  Password
+     * @param serverUrl Url of the server
+     * @param carFile   .car file
+     * @throws Exception if CApp deploy fails
+     */
+    void deployCApp(String username, String password, String serverUrl, File carFile) throws Exception;
+
+    /**
+     * Executes the CApp undeploy logic relevant to the handler.
+     *
+     * @param username  Username
+     * @param password  Password
+     * @param serverUrl Url of the server
+     * @param project   Maven project to extract the CApp properties
+     * @throws Exception if CApp undeploy fails
+     */
+    void unDeployCApp(String username, String password, String serverUrl, MavenProject project) throws Exception;
+
+}

--- a/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/CarbonServer.java
+++ b/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/CarbonServer.java
@@ -17,6 +17,8 @@ public class CarbonServer {
 	
 	private String operation;
 
+	private String serverType;
+
 
 	public String getTrustStorePath() {
 		return trustStorePath;
@@ -85,6 +87,14 @@ public class CarbonServer {
 
 	public String getOperation() {
 		return operation;
+	}
+
+	public void setServerType(String serverType) {
+		this.serverType = serverType;
+	}
+
+	public String getServerType() {
+		return serverType;
 	}
 
 }

--- a/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/EICAppHandler.java
+++ b/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/EICAppHandler.java
@@ -103,8 +103,7 @@ public class EICAppHandler implements CAppHandler {
 
     private Header createBasicAuthHeader(String userName, String password) {
 
-        String concatUserNamePassword = userName + ":" + password;
-        String encodedString = Base64Utils.encode(concatUserNamePassword.getBytes());
-        return new Header(Constants.AUTHORIZATION_HEADER, Constants.BASIC + encodedString);
+        return new Header(Constants.AUTHORIZATION_HEADER,
+                Constants.BASIC + Base64Utils.encode((userName + ":" + password).getBytes()));
     }
 }

--- a/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/EICAppHandler.java
+++ b/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/EICAppHandler.java
@@ -1,0 +1,110 @@
+/*
+ *
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.maven.car.artifact;
+
+import org.apache.axiom.util.base64.Base64Utils;
+import org.apache.commons.httpclient.Header;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.wso2.carbon.application.mgt.stub.upload.types.carbon.UploadedFileItem;
+import org.wso2.carbon.stub.ApplicationAdminStub;
+import org.wso2.carbon.stub.CarbonAppUploaderStub;
+import org.wso2.maven.car.artifact.util.Constants;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.activation.DataHandler;
+
+/**
+ * This class implements CAppHandler to implement the CApp deploy/undeploy logic for EI Servers.
+ */
+public class EICAppHandler implements CAppHandler {
+
+    private final Log logger;
+
+    public EICAppHandler(Log logger) {
+
+        this.logger = logger;
+    }
+
+    @Override
+    public void deployCApp(String username, String password, String serverUrl, File carFile) throws Exception {
+
+        CarbonAppUploaderStub carbonAppUploaderStub = getCarbonAppUploaderStub(username, password, serverUrl);
+        UploadedFileItem uploadedFileItem = new UploadedFileItem();
+        DataHandler param = new DataHandler(carFile.toURI().toURL());
+        uploadedFileItem.setDataHandler(param);
+        uploadedFileItem.setFileName(carFile.getName());
+        uploadedFileItem.setFileType("jar");
+        UploadedFileItem[] fileItems = new UploadedFileItem[]{uploadedFileItem};
+        logger.info("Uploading " + carFile.getName() + " to " + serverUrl + "...");
+        carbonAppUploaderStub.uploadApp(fileItems);
+    }
+
+    @Override
+    public void unDeployCApp(String username, String password, String serverUrl, MavenProject project)
+            throws Exception {
+
+        ApplicationAdminStub appAdminStub = getApplicationAdminStub(serverUrl, username, password);
+        String[] existingApplications = appAdminStub.listAllApplications();
+        if (existingApplications != null && Arrays
+                .asList(existingApplications).contains(project.getArtifactId() + "_" + project.getVersion())) {
+            appAdminStub.deleteApplication(project.getArtifactId() + "_" + project.getVersion());
+            logger.info(
+                    "Located the C-App " + project.getArtifactId() + "_" + project.getVersion() + " and undeployed...");
+        }
+    }
+
+    private CarbonAppUploaderStub getCarbonAppUploaderStub(String username,
+                                                           String pwd, String url) throws Exception {
+
+        CarbonAppUploaderStub carbonAppUploaderStub =
+                new CarbonAppUploaderStub(url + "/services/CarbonAppUploader");
+        Header header = createBasicAuthHeader(username, pwd);
+        List<Header> list = new ArrayList();
+        list.add(header);
+        carbonAppUploaderStub._getServiceClient().getOptions()
+                .setProperty(org.apache.axis2.transport.http.HTTPConstants.HTTP_HEADERS, list);
+        return carbonAppUploaderStub;
+    }
+
+    private ApplicationAdminStub getApplicationAdminStub(String serverURL, String username, String pwd)
+            throws Exception {
+
+        ApplicationAdminStub appAdminStub = new ApplicationAdminStub(serverURL + "/services/ApplicationAdmin");
+        Header header = createBasicAuthHeader(username, pwd);
+        List<Header> list = new ArrayList();
+        list.add(header);
+        appAdminStub._getServiceClient().getOptions()
+                .setProperty(org.apache.axis2.transport.http.HTTPConstants.HTTP_HEADERS, list);
+        return appAdminStub;
+    }
+
+    private Header createBasicAuthHeader(String userName, String password) {
+
+        String concatUserNamePassword = userName + ":" + password;
+        String encodedString = Base64Utils.encode(concatUserNamePassword.getBytes());
+        return new Header(Constants.AUTHORIZATION_HEADER, Constants.BASIC + encodedString);
+    }
+}

--- a/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/MICAppHandler.java
+++ b/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/MICAppHandler.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.maven.car.artifact;
+
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.json.JSONObject;
+import org.wso2.maven.car.artifact.impl.CAppMgtApiHelperServiceImpl;
+
+import java.io.File;
+
+/**
+ * This class implements CAppHandler to implement the CApp deploy/undeploy logic for MI Servers.
+ */
+public class MICAppHandler implements CAppHandler {
+
+    private final CAppMgtApiHelperServiceImpl capppMgtApiHelperServiceImpl;
+    private final Log logger;
+
+    public MICAppHandler(Log logger) {
+
+        this.logger = logger;
+        this.capppMgtApiHelperServiceImpl = new CAppMgtApiHelperServiceImpl();
+    }
+
+    @Override
+    public void deployCApp(String username, String password, String serverUrl, File carFile) throws Exception {
+
+        JSONObject resObj = capppMgtApiHelperServiceImpl.doAuthenticate(serverUrl, username, password);
+        if (resObj != null) {
+            logger.info("Authentication to " + serverUrl + " successful.");
+            String accessToken = resObj.getString("AccessToken");
+            if (accessToken != null && !accessToken.equals("")) {
+                if (capppMgtApiHelperServiceImpl.deployCApp(carFile, accessToken, serverUrl)) {
+                    logger.info("Uploaded " + carFile.getName() + " to " + serverUrl + " ...");
+                }
+            }
+        }
+    }
+
+    @Override
+    public void unDeployCApp(String username, String password, String serverUrl, MavenProject project)
+            throws Exception {
+
+        JSONObject resObj = capppMgtApiHelperServiceImpl.doAuthenticate(serverUrl, username, password);
+        if (resObj != null) {
+            logger.info("Authentication to " + serverUrl + " successful.");
+            String accessToken = resObj.getString("AccessToken");
+            if (accessToken != null && !accessToken.equals("")) {
+                if (capppMgtApiHelperServiceImpl.unDeployCApp(accessToken, serverUrl,
+                        project.getArtifactId() + "_" + project.getVersion())) {
+                    logger.info("Located the C-App " + project.getArtifactId() +
+                            "_" + project.getVersion() + " and undeployed ...");
+                }
+            }
+        }
+    }
+}

--- a/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/MICAppHandler.java
+++ b/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/MICAppHandler.java
@@ -24,6 +24,7 @@ import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.json.JSONObject;
 import org.wso2.maven.car.artifact.impl.CAppMgtApiHelperServiceImpl;
+import org.wso2.maven.car.artifact.util.Constants;
 
 import java.io.File;
 
@@ -47,8 +48,8 @@ public class MICAppHandler implements CAppHandler {
         JSONObject resObj = capppMgtApiHelperServiceImpl.doAuthenticate(serverUrl, username, password);
         if (resObj != null) {
             logger.info("Authentication to " + serverUrl + " successful.");
-            String accessToken = resObj.getString("AccessToken");
-            if (accessToken != null && !accessToken.equals("")) {
+            String accessToken = resObj.getString(Constants.ACCESS_TOKEN);
+            if (isNotBlank(accessToken)) {
                 if (capppMgtApiHelperServiceImpl.deployCApp(carFile, accessToken, serverUrl)) {
                     logger.info("Uploaded " + carFile.getName() + " to " + serverUrl + " ...");
                 }
@@ -63,8 +64,8 @@ public class MICAppHandler implements CAppHandler {
         JSONObject resObj = capppMgtApiHelperServiceImpl.doAuthenticate(serverUrl, username, password);
         if (resObj != null) {
             logger.info("Authentication to " + serverUrl + " successful.");
-            String accessToken = resObj.getString("AccessToken");
-            if (accessToken != null && !accessToken.equals("")) {
+            String accessToken = resObj.getString(Constants.ACCESS_TOKEN);
+            if (isNotBlank(accessToken)) {
                 if (capppMgtApiHelperServiceImpl.unDeployCApp(accessToken, serverUrl,
                         project.getArtifactId() + "_" + project.getVersion())) {
                     logger.info("Located the C-App " + project.getArtifactId() +
@@ -72,5 +73,10 @@ public class MICAppHandler implements CAppHandler {
                 }
             }
         }
+    }
+
+    private static boolean isNotBlank(String accessToken) {
+
+        return accessToken != null && !accessToken.trim().isEmpty();
     }
 }

--- a/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/util/Constants.java
+++ b/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/util/Constants.java
@@ -31,4 +31,5 @@ public class Constants {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BASIC = "Basic ";
+    public static final String ACCESS_TOKEN = "AccessToken";
 }

--- a/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/util/Constants.java
+++ b/maven-car-deploy-plugin/src/main/java/org/wso2/maven/car/artifact/util/Constants.java
@@ -26,4 +26,9 @@ public class Constants {
     public static final int CLIENT_READ_TIMEOUT = 5000;
     public static final String CONFIG_OPERATION_DEPLOY = "deploy";
     public static final String CONFIG_OPERATION_UNDEPLOY = "undeploy";
+    public static final String MI_SERVER = "mi";
+    public static final String EI_SERVER = "ei";
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BASIC = "Basic ";
 }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/maven-tools/issues/86
Fixes https://github.com/wso2/maven-tools/issues/87

## Goals
- Introduce a new property called `serverType` to distinguish MI or EI server (default is mi).
- Use basic auth instead of cookie base authentication.

## User stories
If you need to deploy / undeploy Capps to EI servers, you need to explicitly set the `servertype` to EI as shown below,
```xml
<CarbonServer>
    <trustStorePath>jks_path</trustStorePath>
    <trustStorePassword>wso2carbon</trustStorePassword>
    <trustStoreType>JKS</trustStoreType>
    <serverUrl>https://localhost:9443</serverUrl>
    <userName>admin</userName>
    <password>admin</password>
    <operation>undeploy</operation>
    <serverType>ei</serverType>
</CarbonServer>
```
If not defined, the `servertype` is considered as MI. 
