### PR TITLE
Exclude log4j vulnerable versions

### DIFF
--- a/maven-car-deploy-plugin/pom.xml
+++ b/maven-car-deploy-plugin/pom.xml
@@ -295,17 +295,6 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-<!--		<dependency>-->
-<!--			<groupId>log4j</groupId>-->
-<!--			<artifactId>log4j</artifactId>-->
-<!--			<version>${log4j.version}</version>-->
-<!--			<exclusions>-->
-<!--				<exclusion>-->
-<!--					<groupId>*</groupId>-->
-<!--					<artifactId>*</artifactId>-->
-<!--				</exclusion>-->
-<!--			</exclusions>-->
-<!--		</dependency>-->
 		<dependency>
 			<groupId>commons-httpclient</groupId>
 			<artifactId>commons-httpclient</artifactId>

--- a/maven-car-deploy-plugin/pom.xml
+++ b/maven-car-deploy-plugin/pom.xml
@@ -183,6 +183,12 @@
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-container-default</artifactId>
 			<version>${plexus.container.default.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
@@ -289,17 +295,17 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>${log4j.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>*</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>log4j</groupId>-->
+<!--			<artifactId>log4j</artifactId>-->
+<!--			<version>${log4j.version}</version>-->
+<!--			<exclusions>-->
+<!--				<exclusion>-->
+<!--					<groupId>*</groupId>-->
+<!--					<artifactId>*</artifactId>-->
+<!--				</exclusion>-->
+<!--			</exclusions>-->
+<!--		</dependency>-->
 		<dependency>
 			<groupId>commons-httpclient</groupId>
 			<artifactId>commons-httpclient</artifactId>

--- a/maven-car-plugin/pom.xml
+++ b/maven-car-plugin/pom.xml
@@ -10,19 +10,19 @@
 	language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-	<parent>
+       <parent>
 		<groupId>org.wso2.maven</groupId>
 		<artifactId>maven-common-tools</artifactId>
 		<version>5.2.39-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
-	</parent>
+       </parent>
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.wso2.maven</groupId>
+        <groupId>org.wso2.maven</groupId>
 	<artifactId>maven-car-plugin</artifactId>
 	<version>5.2.39-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
-	<url>http://wso2.org</url>
+        <url>http://wso2.org</url>
 
 	<name>Maven CAR Plugin</name>
 	<description>Maven plugin which creates CAR artifact</description>

--- a/maven-car-plugin/pom.xml
+++ b/maven-car-plugin/pom.xml
@@ -10,19 +10,19 @@
 	language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-       <parent>
+	<parent>
 		<groupId>org.wso2.maven</groupId>
 		<artifactId>maven-common-tools</artifactId>
 		<version>5.2.39-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
-       </parent>
+	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
-        <groupId>org.wso2.maven</groupId>
+	<groupId>org.wso2.maven</groupId>
 	<artifactId>maven-car-plugin</artifactId>
 	<version>5.2.39-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
-        <url>http://wso2.org</url>
+	<url>http://wso2.org</url>
 
 	<name>Maven CAR Plugin</name>
 	<description>Maven plugin which creates CAR artifact</description>
@@ -122,6 +122,12 @@
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-container-default</artifactId>
 			<version>${plexus.container.default.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>
@@ -181,6 +187,12 @@
 			<groupId>org.wso2.maven</groupId>
 			<artifactId>maven-stratos-plugin</artifactId>
 			<version>${org.wso2.maven.stratos.plugin.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
## Purpose

- Exclude the vulnerable log4j dependencies versions from the maven-car-plugin and maven-car-deploy-plugin.
- Public git issue is N/A.

## Approach
- Removed the log4j from the dependencies that uses vulnerable versions, with the exclusion tag.