### PR TITLE
Exclude log4j vulnerable versions from vulnerable plugins

### DIFF
--- a/maven-carbon-ui-plugin/pom.xml
+++ b/maven-carbon-ui-plugin/pom.xml
@@ -121,6 +121,12 @@
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-container-default</artifactId>
 			<version>${plexus.container.default.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>

--- a/maven-datasource-plugin/pom.xml
+++ b/maven-datasource-plugin/pom.xml
@@ -127,6 +127,12 @@
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-container-default</artifactId>
 			<version>${plexus.container.default.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>

--- a/wso2-esb-metadata-plugin/pom.xml
+++ b/wso2-esb-metadata-plugin/pom.xml
@@ -112,6 +112,12 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-container-default</artifactId>
             <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>

--- a/wso2-general-project-plugin/pom.xml
+++ b/wso2-general-project-plugin/pom.xml
@@ -109,6 +109,12 @@
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-container-default</artifactId>
 			<version>${plexus.container.default.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
## Purpose
Exclude the vulnerable log4j dependencies from the identified plugins.
## Approach
1. Mostly the log4j are fetched as dependencies due to they are being transitive dependencies.
2. Excluded the log4j from main dependency.
3. These plugins have the log4j get removed,

- maven-carbon-ui-plugin
- maven-datasource-plugin
- wso2-esb-metadata-plugin
- wso2-general-project-plugin
- humantask-maven-plugin (Using log4j from transitive dependency - pending bump up)

## PRs and Issues
Fix #102 
Related to https://github.com/wso2-enterprise/wso2-apim-internal/issues/1234