### PR TITLE
Add registry resources as text values

### DIFF
--- a/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/SynapseTestCaseFileReader.java
+++ b/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/SynapseTestCaseFileReader.java
@@ -239,15 +239,7 @@ class SynapseTestCaseFileReader {
             }
 
             if (registryResourceFileAsString != null) {
-                //add registry resource data as a child data in artifact node
-                if (registryResourceFileAsString.startsWith("<")) {
-                    OMElement registryArtifactDataNode = AXIOMUtil.stringToOM(registryResourceFileAsString);
-                    registryResourcesFileNode.removeChildren();
-
-                    registryResourcesFileNode.addChild(registryArtifactDataNode);
-                } else {
-                    registryResourcesFileNode.setText(registryResourceFileAsString);
-                }
+                registryResourcesFileNode.setText(registryResourceFileAsString);
             } else {
                 throw new IOException("Registry resource does not contain any configuration data");
             }


### PR DESCRIPTION
## Purpose
Previously resource values starting with '<' were added as OMElements. As a result, XML parse exceptions occur when freemarker templates are defined in the registry. Since parsing XML files(endpoints, sequences) as text gets them deployed properly in the mock registry, we can omit considering them as OMElements. 

Fixes https://github.com/wso2/api-manager/issues/1262