### PR TITLE
Add missing maven plugins related to ESB artifacts

### DIFF
--- a/maven-dataservice-plugin/pom.xml
+++ b/maven-dataservice-plugin/pom.xml
@@ -1,0 +1,191 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.maven</groupId>
+        <artifactId>maven-common-tools</artifactId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>maven-dataservice-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Maven Dataservice Plugin</name>
+
+    <description>Maven plugin which creates and builds Dataservice artifacts</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${org.apache.maven.plugin.testing.harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>run-its</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.4</version>
+                        <configuration>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>package</goal>
+                            </goals>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/DSSArtifact.java
+++ b/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/DSSArtifact.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.dataservice;
+
+public class DSSArtifact {
+
+    private String name;
+    private String version;
+    private String serverRole;
+    private String type;
+    private String groupId;
+
+    private String file;
+
+    public String getName() {
+
+        return name;
+    }
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public String getVersion() {
+
+        return version;
+    }
+
+    public void setVersion(String version) {
+
+        this.version = version;
+    }
+
+    public String getServerRole() {
+
+        return serverRole;
+    }
+
+    public void setServerRole(String serverRole) {
+
+        this.serverRole = serverRole;
+    }
+
+    public String getType() {
+
+        return type;
+    }
+
+    public void setType(String type) {
+
+        this.type = type;
+    }
+
+    public void setFile(String file) {
+
+        this.file = file;
+    }
+
+    public String getFile() {
+
+        return file;
+    }
+
+    public boolean isAnonymous() {
+
+        return name != null ? false : true;
+    }
+
+    public void setGroupId(String groupId) {
+
+        this.groupId = groupId;
+    }
+
+    public String getGroupId() {
+
+        return groupId;
+    }
+
+}

--- a/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/DSSProjectArtifacts.java
+++ b/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/DSSProjectArtifacts.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.dataservice;
+
+import org.apache.axiom.om.OMDocument;
+import org.apache.axiom.om.OMElement;
+import org.wso2.maven.core.model.AbstractXMLDoc;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Observable;
+import java.util.Observer;
+
+import javax.xml.stream.FactoryConfigurationError;
+
+public class DSSProjectArtifacts extends AbstractXMLDoc implements Observer {
+
+    List<DSSArtifact> dssArtifacts = new ArrayList<DSSArtifact>();
+    private File source;
+
+    public void update(Observable o, Object arg) {
+
+    }
+
+    @Override
+    protected void deserialize(OMElement documentElement) throws Exception {
+
+        List<OMElement> artifactElements = getChildElements(documentElement, "artifact");
+        for (OMElement omElement : artifactElements) {
+            DSSArtifact artifact = new DSSArtifact();
+            artifact.setName(getAttribute(omElement, "name"));
+            artifact.setVersion(getAttribute(omElement, "version"));
+            artifact.setType(getAttribute(omElement, "type"));
+            artifact.setServerRole(getAttribute(omElement, "serverRole"));
+            artifact.setGroupId(getAttribute(omElement, "groupId"));
+            artifact.setFile(getChildElements(omElement, "file").size() > 0 ?
+                    getChildElements(omElement, "file").get(0).getText() : null);
+            dssArtifacts.add(artifact);
+        }
+
+    }
+
+    @Override
+    protected String serialize() throws Exception {
+
+        String result = null;
+        OMDocument document = factory.createOMDocument();
+        OMElement documentElement = getDocumentElement();
+        document.addChild(documentElement);
+        try {
+            result = getPretifiedString(documentElement);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+        return result;
+    }
+
+    @Override
+    protected String getDefaultName() {
+
+        return null;
+    }
+
+    public void addDSSArtifact(DSSArtifact artifact) {
+
+        dssArtifacts.add(artifact);
+    }
+
+    public boolean removeDSSArtifact(DSSArtifact artifact) {
+
+        return dssArtifacts.remove(artifact);
+    }
+
+    public List<DSSArtifact> getAllDSSArtifacts() {
+
+        return Collections.unmodifiableList(dssArtifacts);
+    }
+
+    public OMElement getDocumentElement() {
+
+        OMElement documentElement = getElement("artifacts", "");
+
+        for (DSSArtifact dssArtifact : dssArtifacts) {
+            OMElement artifactElement = getElement("artifact", "");
+
+            if (!dssArtifact.isAnonymous()) {
+                addAttribute(artifactElement, "name", dssArtifact.getName());
+            }
+
+            if (!dssArtifact.isAnonymous() && dssArtifact.getGroupId() != null) {
+                addAttribute(artifactElement, "groupId", dssArtifact.getGroupId());
+            }
+
+            if (!dssArtifact.isAnonymous() && dssArtifact.getVersion() != null) {
+                addAttribute(artifactElement, "version", dssArtifact.getVersion());
+            }
+
+            if (dssArtifact.getType() != null) {
+                addAttribute(artifactElement, "type", dssArtifact.getType());
+            }
+
+            if (dssArtifact.getServerRole() != null) {
+                addAttribute(artifactElement, "serverRole", dssArtifact.getServerRole());
+            }
+
+            if (dssArtifact.getFile() != null) {
+                artifactElement.addChild(getElement("file", dssArtifact.getFile()));
+            }
+
+            documentElement.addChild(artifactElement);
+        }
+
+        return documentElement;
+    }
+
+    public void setSource(File source) {
+
+        this.source = source;
+    }
+
+    public File getSource() {
+
+        return source;
+    }
+
+    public File toFile() throws Exception {
+
+        File savedFile = new File(toFile(getSource()).toString());
+        return savedFile;
+    }
+
+    public void fromFile(File file) throws FactoryConfigurationError, Exception {
+
+        setSource(file);
+        if (getSource().exists()) {
+            deserialize(getSource());
+        }
+    }
+
+}

--- a/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/DataServiceMojo.java
+++ b/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/DataServiceMojo.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.dataservice;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is the Maven Mojo used for dataservice resources to be copied to the output directory in the resource-process
+ * phase.
+ *
+ * @goal package-dataservice
+ */
+public class DataServiceMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${package-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${package-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        File destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            } else {
+                String[] fileNameSplit = (artifact.getName().split("\\."));
+                String extension = fileNameSplit[fileNameSplit.length - 1];
+                String fileNameWithoutExtension = "";
+                if (artifact.getName().indexOf(".") > 0) {
+                    fileNameWithoutExtension = artifact.getName().substring(0, artifact.getName().lastIndexOf("."));
+                }
+
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            }
+        }
+
+        File result = new File(newPath);
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " + result.getName()
+                    + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+
+    }
+
+}

--- a/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/DataServicePOMGenMojo.java
+++ b/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/DataServicePOMGenMojo.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.dataservice;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.plugin.dataservice.utils.DSSMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a dataservice artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class DataServicePOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    public MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    public MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    public File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    public File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    public File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    public String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when
+     * creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private static final String ARTIFACT_TYPE = "service/dataservice";
+
+    private List<DSSArtifact> retrieveArtifacts() {
+
+        return DSSMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        List<DSSArtifact> artifacts = retrieveArtifacts();
+
+        // Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        for (DSSArtifact dssArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(dssArtifact.getName());
+            artifact.setVersion(dssArtifact.getVersion());
+            artifact.setType(dssArtifact.getType());
+            artifact.setServerRole(dssArtifact.getServerRole());
+            artifact.setFile(dssArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        File dataServiceArtifact = processTokenReplacement(artifact);
+        if (dataServiceArtifact == null) {
+            dataServiceArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(dataServiceArtifact, new File(projectLocation, artifact.getFile().getName()));
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject,
+                              Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject,
+                MavenConstants.WSO2_MAVEN_GROUPID, "maven-dataservice-plugin",
+                WSO2MavenPluginConstantants.MAVEN_DATA_SERVICE_PLUGIN_VERSION,
+                true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        // add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(
+                configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+
+}

--- a/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/utils/DSSMavenUtils.java
+++ b/maven-dataservice-plugin/src/main/java/org/wso2/maven/plugin/dataservice/utils/DSSMavenUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.dataservice.utils;
+
+import org.wso2.maven.plugin.dataservice.DSSArtifact;
+import org.wso2.maven.plugin.dataservice.DSSProjectArtifacts;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DSSMavenUtils {
+
+    private static List<String> excludeList = new ArrayList<String>();
+
+    static {
+        excludeList.add(".svn");
+    }
+
+    public static List<DSSArtifact> retrieveArtifacts(File path) {
+
+        return retrieveArtifacts(new File(path, "artifact.xml"), new ArrayList<DSSArtifact>());
+    }
+
+    private static List<DSSArtifact> retrieveArtifacts(File path, List<DSSArtifact> artifacts) {
+
+        if (path.exists()) {
+            if (path.isFile()) {
+                DSSProjectArtifacts artifact = new DSSProjectArtifacts();
+                try {
+                    artifact.fromFile(path);
+                    for (DSSArtifact dssArtifact : artifact.getAllDSSArtifacts()) {
+                        if (dssArtifact.getVersion() != null && dssArtifact.getType() != null) {
+                            artifacts.add(dssArtifact);
+                        }
+                    }
+                } catch (Exception e) {
+                    //not an artifact
+                }
+            } else {
+                File[] files = path.listFiles();
+                for (File file : files) {
+                    if (!excludeList.contains(file.getName())) {
+                        retrieveArtifacts(file, artifacts);
+                    }
+                }
+            }
+        }
+        return artifacts;
+    }
+
+}

--- a/maven-dataservice-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/maven-dataservice-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,57 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>service/dataservice</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:maven-dataservice-plugin:package-dataservice</package>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>service/dataservice</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>service/dataservice</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>dbs</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/maven-dataservice-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/maven-dataservice-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>service/dataservice</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-dataservice-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <!-- <configuration> <artifact>src/main/resources/dataservice/dataservice.dbs</artifact>
+                    </configuration> -->
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/maven-datasource-plugin/src/main/java/org/wso2/maven/plugin/datasource/utils/WSO2MavenDSSPluginConstantants.java
+++ b/maven-datasource-plugin/src/main/java/org/wso2/maven/plugin/datasource/utils/WSO2MavenDSSPluginConstantants.java
@@ -1,5 +1,5 @@
 package org.wso2.maven.plugin.datasource.utils;
 
 public class WSO2MavenDSSPluginConstantants {
-	public static final String MAVEN_DATA_SOURCE_PLUGIN_VERSION ="1.0.0";
+	public static final String MAVEN_DATA_SOURCE_PLUGIN_VERSION ="5.2.42";
 }

--- a/maven-synapse-plugin/pom.xml
+++ b/maven-synapse-plugin/pom.xml
@@ -1,0 +1,195 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<parent>
+		<artifactId>maven-common-tools</artifactId>
+		<groupId>org.wso2.maven</groupId>
+		<version>5.2.42-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>maven-synapse-plugin</artifactId>
+	<version>5.2.42-SNAPSHOT</version>
+	<packaging>maven-plugin</packaging>
+
+	<name>Maven ESB Synapse Configuration Plugin</name>
+
+	<description>Maven plugin which creates and builds Synapse configuration artifacts</description>
+	<build>
+		<extensions>
+			<extension>
+				<groupId>org.apache.maven.wagon</groupId>
+				<artifactId>wagon-ssh</artifactId>
+				<version>1.0-beta-6</version>
+			</extension>
+		</extensions>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.5</source>
+					<target>1.5</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	<dependencies>
+		<dependency>
+			<groupId>biz.aQute</groupId>
+			<artifactId>bndlib</artifactId>
+			<version>${bndlib.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>net.sf.kxml</groupId>
+			<artifactId>kxml2</artifactId>
+			<version>${kxml2.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.apache.felix.bundlerepository</artifactId>
+			<version>${org.apache.felix.bundlerepository.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.osgi.core</artifactId>
+			<version>${org.apache.felix.org.osgi.core.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>org.osgi.service.obr</artifactId>
+			<version>${org.apache.felix.org.osgi.service.obr.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-project</artifactId>
+			<version>${org.apache.maven.project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-model</artifactId>
+			<version>${org.apache.maven.model.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>${org.apache.maven.plugin.api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-artifact</artifactId>
+			<version>${org.apache.maven.artifact.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-archiver</artifactId>
+			<version>${org.apache.maven.archiver.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-artifact-manager</artifactId>
+			<version>${org.apache.maven.artifact.manager.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-settings</artifactId>
+			<version>${org.apache.maven.settings.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-dependency-tree</artifactId>
+			<version>${org.apache.maven.dependency.tree.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.wagon</groupId>
+			<artifactId>wagon-provider-api</artifactId>
+			<version>${org.apache.maven.wagon.provider.api.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-container-default</artifactId>
+			<version>${plexus.container.default.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>log4j</groupId>
+					<artifactId>log4j</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-archiver</artifactId>
+			<version>${plexus.archiver.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>${plexus.utils.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.shared</groupId>
+			<artifactId>maven-plugin-testing-harness</artifactId>
+			<version>${org.apache.maven.plugin.testing.harness.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>commons-io.wso2</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>${commons.io.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.wso2.maven</groupId>
+			<artifactId>org.wso2.maven.capp</artifactId>
+			<version>${org.wso2.maven.capp.version}</version>
+		</dependency>
+	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>run-its</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-invoker-plugin</artifactId>
+						<version>1.4</version>
+						<configuration>
+							<projectsDirectory>src/it</projectsDirectory>
+							<pomIncludes>
+								<pomInclude>*/pom.xml</pomInclude>
+							</pomIncludes>
+							<postBuildHookScript>verify</postBuildHookScript>
+							<localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+							<goals>
+								<goal>clean</goal>
+								<goal>package</goal>
+							</goals>
+							<settingsFile>src/it/settings.xml</settingsFile>
+							<cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+						</configuration>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<goals>
+									<goal>install</goal>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/SynapseMojo.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/SynapseMojo.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is the Maven Mojo used for synapse configuration resource to be copied to the output
+ * directory in the resource-process phase.
+ *
+ * @goal package-synapse
+ */
+public class SynapseMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${package-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${package-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        File destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            } else {
+                String[] fileNameSplit = (artifact.getName().split("\\."));
+                String extension = fileNameSplit[fileNameSplit.length - 1];
+                String fileNameWithoutExtension = "";
+                if (artifact.getName().indexOf(".") > 0) {
+                    fileNameWithoutExtension = artifact.getName().substring(0, artifact.getName().lastIndexOf("."));
+                }
+
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/SynapsePOMGenMojo.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/SynapsePOMGenMojo.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class SynapsePOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    public MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    public MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    public File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    public File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    public File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    public String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private static final String ARTIFACT_TYPE = "synapse/configuration";
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        File sequenceArtifact = artifact.getFile();
+        FileUtils.copyFile(sequenceArtifact, new File(projectLocation, sequenceArtifact.getName()));
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject, "org.wso2.maven", "maven-synapse-plugin",
+                WSO2MavenPluginConstantants.MAVEN_SYNAPSE_PLUGIN_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/AbstractSynapseDependentArtifactExporter.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/AbstractSynapseDependentArtifactExporter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMDocument;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.project.MavenProject;
+import org.wso2.maven.capp.model.CAppArtifactDependency;
+import org.wso2.maven.core.utils.MavenUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+/**
+ * An abstract implementation of {@link SynapseDependentArtifactExporter}.
+ */
+public abstract class AbstractSynapseDependentArtifactExporter implements SynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    public CAppArtifactDependency export(OMElement artifactDefinition, CAppArtifactDependency synapseArtifactClone,
+                                         File workDir)
+            throws Exception {
+        // Create the temporary directory.
+        workDir.mkdirs();
+        // Serialize the sequence definition.
+        String artifactName = getArtifactName(artifactDefinition);
+        File artifactContentFile = new File(workDir, String.format("%s.xml", artifactName));
+        FileOutputStream fos = null;
+        try {
+            fos = new FileOutputStream(artifactContentFile);
+            OMFactory omFactory = OMAbstractFactory.getOMFactory();
+            OMDocument omDocument = omFactory.createOMDocument();
+            omDocument.addChild(artifactDefinition);
+            omDocument.serialize(fos);
+        } finally {
+            IOUtils.closeQuietly(fos);
+        }
+
+        // Create the sequence artifact.
+        MavenProject dummyMavenProject = MavenUtils
+                .createMavenProject(synapseArtifactClone.getcAppArtifact().getProject().getGroupId(), artifactName,
+                        synapseArtifactClone.getVersion(), getArtifactType());
+        CAppArtifactDependency cAppArtifactDependency =
+                new CAppArtifactDependency(dummyMavenProject, getArtifactType(), synapseArtifactClone.getServerRole());
+        cAppArtifactDependency.setDummyDependency(true);
+        cAppArtifactDependency.setArtifactFiles(new File[]{artifactContentFile});
+        cAppArtifactDependency.getcAppArtifact().setFile(artifactContentFile.getName());
+        return cAppArtifactDependency;
+    }
+
+    /**
+     * Determines the name of the artifact which is to be exported.
+     *
+     * @param artifactDefinition serialized form of the artifact.
+     * @return artifact name.
+     */
+    protected abstract String getArtifactName(OMElement artifactDefinition);
+
+    /**
+     * Determines the type of the artifact to be exported.
+     *
+     * @return artifact type identifier string.
+     */
+    protected abstract String getArtifactType();
+
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/EndPointArtifactExporter.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/EndPointArtifactExporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import javax.xml.namespace.QName;
+
+/**
+ * {@link SynapseDependentArtifactExporter} corresponding to <endpoint/> tag.
+ */
+public class EndPointArtifactExporter extends AbstractSynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactName(OMElement artifactDefinition) {
+
+        return artifactDefinition.getAttributeValue(new QName("name"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactType() {
+
+        return "synapse/endpoint";
+    }
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/LocalEntryArtifactExporter.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/LocalEntryArtifactExporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import javax.xml.namespace.QName;
+
+/**
+ * {@link SynapseDependentArtifactExporter} corresponding to <localEntry/> tag.
+ */
+public class LocalEntryArtifactExporter extends AbstractSynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactName(OMElement artifactDefinition) {
+
+        return artifactDefinition.getAttributeValue(new QName("key"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactType() {
+
+        return "synapse/local-entry";
+    }
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/ProxyServiceArtifactExporter.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/ProxyServiceArtifactExporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import javax.xml.namespace.QName;
+
+/**
+ * {@link SynapseDependentArtifactExporter} corresponding to <localEntry/> tag.
+ */
+public class ProxyServiceArtifactExporter extends AbstractSynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactName(OMElement artifactDefinition) {
+
+        return artifactDefinition.getAttributeValue(new QName("name"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactType() {
+
+        return "synapse/proxy-service";
+    }
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SequenceArtifactExporter.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SequenceArtifactExporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import javax.xml.namespace.QName;
+
+/**
+ * {@link SynapseDependentArtifactExporter} corresponding to <sequence/> tag.
+ */
+public class SequenceArtifactExporter extends AbstractSynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactName(OMElement artifactDefinition) {
+
+        return artifactDefinition.getAttributeValue(new QName("name"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactType() {
+
+        return "synapse/sequence";
+    }
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseArtifactBundleCreator.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseArtifactBundleCreator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.io.IOUtils;
+import org.wso2.developerstudio.eclipse.utils.file.FileUtils;
+import org.wso2.maven.capp.model.CAppArtifactDependency;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A specialization of {@link ArtifactBundleCreator} used to explode synapse
+ * configuration artifacts into multiple artifacts at car generation.
+ */
+public class SynapseArtifactBundleCreator {
+
+    /**
+     * Dependent artifact exporter factory.
+     */
+    private SynapseDependentArtifactExporterFactory exporterFactory;
+
+    private CAppArtifactDependency artifact;
+
+    /**
+     * Creates a new {@link SynapseArtifactBundleCreator} instance.
+     *
+     * @param artifact synapse configuration artifact.
+     */
+    public SynapseArtifactBundleCreator(CAppArtifactDependency artifact) {
+
+        setArtifact(artifact);
+        exporterFactory = SynapseDependentArtifactExporterFactory.getInstance();
+    }
+
+    /**
+     * Exports any dependent artifacts that can be extracted from this synapse
+     * configuration artifacts.
+     *
+     * @param synapseXmlFile       synapse.xml file.
+     * @param synapseArtifactClone clone of the original synapse artifact.
+     * @throws Exception if an error is encountered while performing the explode
+     *                   operation.
+     */
+    public List<CAppArtifactDependency> exportDependentArtifacts(File synapseXmlFile,
+                                                                 CAppArtifactDependency synapseArtifactClone)
+            throws Exception {
+
+        FileInputStream fis = null;
+        List<CAppArtifactDependency> list = new ArrayList<CAppArtifactDependency>();
+        try {
+            // Parse the synapse.xml file into an OMDocument.
+            fis = new FileInputStream(synapseXmlFile);
+            StAXOMBuilder builder = new StAXOMBuilder(fis);
+            OMElement documentElement = builder.getDocumentElement();
+            documentElement.build();
+
+            // Iterate through all the top level elements looking for sub
+            // artifacts that can be extracted.
+            Iterator<?> iter = documentElement.getChildElements();
+            while (iter.hasNext()) {
+                OMElement childElement = (OMElement) iter.next();
+                SynapseDependentArtifactExporter exporter = exporterFactory.getExporter(childElement.getLocalName());
+                if (null != exporter) {
+                    // Create a working directory only if we have at least one
+                    // exporter.
+                    File workDir = FileUtils.createTempDirectory();
+                    try {
+                        CAppArtifactDependency dependency =
+                                exporter.export(childElement, synapseArtifactClone, workDir);
+                        if (dependency != null) {
+                            list.add(dependency);
+                        }
+                    } catch (Exception ex) {
+                    }
+                }
+            }
+        } finally {
+            // Close file input stream.
+            IOUtils.closeQuietly(fis);
+        }
+        return list;
+    }
+
+    public void setArtifact(CAppArtifactDependency artifact) {
+
+        this.artifact = artifact;
+    }
+
+    public CAppArtifactDependency getArtifact() {
+
+        return artifact;
+    }
+
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseDependentArtifactExporter.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseDependentArtifactExporter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+import org.wso2.maven.capp.model.CAppArtifactDependency;
+
+import java.io.File;
+
+/**
+ * Interface for synapse dependent artifact exporters.
+ */
+public interface SynapseDependentArtifactExporter {
+
+    /**
+     * Exports the specified dependent artifact into the directory specified by
+     * <strong>contentLocation</strong> argument. This method will update the
+     * <strong>synapseArtifact</strong> to reflect the newly added dependency.
+     *
+     * @param artifactDefinition   artifact definition {@link OMElement}.
+     * @param synapseArtifactClone clone of the synapse artifact from which this dependent
+     *                             artifact was extracted from.
+     * @param workDir              temporary working directory.
+     * @throws Exception if an error occurs while exporting the artifact.
+     */
+    CAppArtifactDependency export(OMElement artifactDefinition, CAppArtifactDependency synapseArtifactClone,
+                                  File workDir)
+            throws Exception;
+
+}

--- a/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseDependentArtifactExporterFactory.java
+++ b/maven-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseDependentArtifactExporterFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A singleton factory for creating {@link SynapseDependentArtifactExporter}
+ * instances.
+ */
+public class SynapseDependentArtifactExporterFactory {
+
+    /**
+     * Singleton factory.
+     */
+    private static SynapseDependentArtifactExporterFactory singleton;
+
+    /**
+     * A map of {@link OMElement} local name to corresponding {@link SynapseDependentArtifactExporter} instances.
+     */
+    private Map<String, SynapseDependentArtifactExporter> localNameToExportersMap;
+
+    /**
+     * Private constructor.
+     */
+    private SynapseDependentArtifactExporterFactory() {
+
+        localNameToExportersMap = new HashMap<String, SynapseDependentArtifactExporter>();
+
+        // Initialize exporters.
+        localNameToExportersMap.put("sequence", new SequenceArtifactExporter());
+        localNameToExportersMap.put("endpoint", new EndPointArtifactExporter());
+        localNameToExportersMap.put("localEntry", new LocalEntryArtifactExporter());
+        localNameToExportersMap.put("proxy", new ProxyServiceArtifactExporter());
+    }
+
+    /**
+     * @return singleton factory instance.
+     */
+    public static final SynapseDependentArtifactExporterFactory getInstance() {
+
+        if (null == singleton) {
+            singleton = new SynapseDependentArtifactExporterFactory();
+        }
+
+        return singleton;
+    }
+
+    /**
+     * Returns the {@link SynapseDependentArtifactExporter} corresponding to the
+     * specified local name.
+     *
+     * @param localName local name of the {@link OMElement} which represents the
+     *                  serialized form of dependent artifact.
+     * @return {@link SynapseDependentArtifactExporter} corresponding to the
+     * specified local name or null if no exporter is found.
+     */
+    public SynapseDependentArtifactExporter getExporter(String localName) {
+
+        return localNameToExportersMap.get(localName);
+    }
+}

--- a/maven-synapse-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-synapse-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-sequence-plugin">
+	<requiredProperties>
+		<requiredProperty key="testParam">
+			<defaultValue>testValue</defaultValue>
+		</requiredProperty>
+	</requiredProperties>
+	<fileSets>
+		<fileSet filtered="true" encoding="UTF-8">
+			<directory>src/main/resources/sample</directory>
+		</fileSet>
+	</fileSets>
+</archetype-descriptor>

--- a/maven-synapse-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/maven-synapse-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+  <id>maven-sequence-plugin</id>
+ <resources>
+    <resource>src/main/resources/sample/sample-sequence.xml</resource>
+  </resources>
+</archetype>

--- a/maven-synapse-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/maven-synapse-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,55 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+  <components>
+    <component>
+      <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+      <role-hint>synapse/configuration</role-hint>
+      <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+      <configuration>
+        <lifecycles>
+          <lifecycle>
+            <id>default</id>
+            <phases>
+	      <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
+              <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+              <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
+              <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+              <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+              <package>org.wso2.maven:maven-synapse-plugin:package-synapse</package>
+              <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+              <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+            </phases>
+          </lifecycle>
+        </lifecycles>
+      </configuration>
+    </component>
+<component>
+      <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+      <role-hint>synapse/configuration</role-hint>
+      <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+      <configuration>
+        <type>synapse/configuration</type>
+        <includesDependencies>false</includesDependencies>
+        <extension>xml</extension>
+        <addedToClasspath>false</addedToClasspath>
+      </configuration>
+    </component>
+  </components>
+</component-set>

--- a/maven-synapse-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/maven-synapse-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>${groupId}</groupId>
+	<artifactId>${artifactId}</artifactId>
+	<version>${version}</version>
+	<packaging>synapse/sequence</packaging>
+	<name>${artifactId}</name>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.wso2.maven</groupId>
+				<artifactId>maven-sequence-plugin</artifactId>
+                <version>2.1.0</version>
+        		<extensions>true</extensions> 
+				<configuration>
+					<artifact>src/main/resources/sample/sample-sequence.xml</artifact>
+				</configuration> 
+             		</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/maven-synapse-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-sequence.xml
+++ b/maven-synapse-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-sequence.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence xmlns="http://ws.apache.org/ns/synapse" name="${artifactId}"/>

--- a/org.wso2.maven.capp/src/main/java/org/wso2/maven/capp/utils/WSO2MavenPluginConstantants.java
+++ b/org.wso2.maven.capp/src/main/java/org/wso2/maven/capp/utils/WSO2MavenPluginConstantants.java
@@ -1,11 +1,11 @@
 package org.wso2.maven.capp.utils;
 
 public class WSO2MavenPluginConstantants {
-	public static final String MAVEN_CARBON_UI_PLUGIN_VERSION="2.1.0";
-	public static final String MAVEN_CAR_PLUGIN_VERSION="2.1.0";
+	public static final String MAVEN_CARBON_UI_PLUGIN_VERSION="5.2.42";
+	public static final String MAVEN_CAR_PLUGIN_VERSION="5.2.42";
 	public static final String WSO2_GENERAL_PROJECT_VERSION = "2.1.0";
 	public static final String MAVEN_CAR_DEPLOY_PLUGIN_VERSION="1.1.0";
-	public static final String MAVEN_REGISTRY_PLUGIN_VERSION = "2.1.0";
+	public static final String MAVEN_REGISTRY_PLUGIN_VERSION = "5.2.42";
 	public static final String MAVEN_DATA_SERVICE_PLUGIN_VERSION = "5.2.42";
 	public static final String MAVEN_SYNAPSE_PLUGIN_VERSION = "5.2.42";
 	public static final String WSO2_ESB_API_VERSION = "5.2.42";
@@ -20,4 +20,5 @@ public class WSO2MavenPluginConstantants {
 	public static final String WSO2_ESB_PROXY_VERSION = "5.2.42";
 	public static final String WSO2_ESB_SEQUENCE_VERSION = "5.2.42";
 	public static final String WSO2_ESB_SYNAPSE_VERSION = "5.2.42";
+	public static final String WSO2_ESB_METADATA_PLUGIN_VERSION = "5.2.42";
 }

--- a/org.wso2.maven.capp/src/main/java/org/wso2/maven/capp/utils/WSO2MavenPluginConstantants.java
+++ b/org.wso2.maven.capp/src/main/java/org/wso2/maven/capp/utils/WSO2MavenPluginConstantants.java
@@ -6,5 +6,18 @@ public class WSO2MavenPluginConstantants {
 	public static final String WSO2_GENERAL_PROJECT_VERSION = "2.1.0";
 	public static final String MAVEN_CAR_DEPLOY_PLUGIN_VERSION="1.1.0";
 	public static final String MAVEN_REGISTRY_PLUGIN_VERSION = "2.1.0";
-
+	public static final String MAVEN_DATA_SERVICE_PLUGIN_VERSION = "5.2.42";
+	public static final String MAVEN_SYNAPSE_PLUGIN_VERSION = "5.2.42";
+	public static final String WSO2_ESB_API_VERSION = "5.2.42";
+	public static final String WSO2_ESB_CONNECTOR_VERSION = "5.2.42";
+	public static final String WSO2_ESB_TASK_VERSION = "5.2.42";
+	public static final String WSO2_ESB_TEMPLATE_VERSION = "5.2.42";
+	public static final String WSO2_ESB_MESSAGE_STORE_PLUGIN_VERSION = "5.2.42";
+	public static final String WSO2_ESB_MESSAGE_PROCESSOR_PLUGIN_VERSION = "5.2.42";
+	public static final String WSO2_ESB_ENDPOINT_VERSION = "5.2.42";
+	public static final String WSO2_ESB_INBOUND_ENDPOINT_VERSION = "5.2.42";
+	public static final String WSO2_ESB_LOCAL_ENTRY_VERSION = "5.2.42";
+	public static final String WSO2_ESB_PROXY_VERSION = "5.2.42";
+	public static final String WSO2_ESB_SEQUENCE_VERSION = "5.2.42";
+	public static final String WSO2_ESB_SYNAPSE_VERSION = "5.2.42";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,20 @@
         <module>wso2-mi-config-mapper</module>
         <module>wso2-general-project-plugin</module>
         <module>wso2-esb-metadata-plugin</module>
+        <module>maven-synapse-plugin</module>
+        <module>wso2-esb-api-plugin</module>
+        <module>wso2-esb-connector-plugin</module>
+        <module>wso2-esb-endpoint-plugin</module>
+        <module>wso2-esb-inboundendpoint-plugin</module>
+        <module>wso2-esb-localentry-plugin</module>
+        <module>wso2-esb-messageprocessor-plugin</module>
+        <module>wso2-esb-messagestore-plugin</module>
+        <module>wso2-esb-proxy-plugin</module>
+        <module>wso2-esb-sequence-plugin</module>
+        <module>wso2-esb-synapse-plugin</module>
+        <module>wso2-esb-task-plugin</module>
+        <module>wso2-esb-template-plugin</module>
+        <module>maven-dataservice-plugin</module>
     </modules>
     <build>
         <extensions>
@@ -260,7 +274,7 @@
         <org.wso2.securevault.version>1.0.0</org.wso2.securevault.version>
         <org.wso2.carbon.authenticator.stub.version>3.2.0</org.wso2.carbon.authenticator.stub.version>
         <org.wso2.carbon.roles.mgt.stub.version>3.2.0</org.wso2.carbon.roles.mgt.stub.version>
-        <org.wso2.maven.synapse.plugin.version>2.1.0</org.wso2.maven.synapse.plugin.version>
+        <org.wso2.maven.synapse.plugin.version>5.2.42-SNAPSHOT</org.wso2.maven.synapse.plugin.version>
         <org.wso2.maven.stratos.plugin.version>2.1.0</org.wso2.maven.stratos.plugin.version>
         <org.wso2.maven.capp.version>5.2.42-SNAPSHOT</org.wso2.maven.capp.version>
         <org.wso2.maven.core.version>5.2.42-SNAPSHOT</org.wso2.maven.core.version>

--- a/wso2-esb-api-plugin/pom.xml
+++ b/wso2-esb-api-plugin/pom.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2023, WSO2 LLC (https://www.wso2.com) All Rights Reserved.
+ ~
+ ~ WSO2 LCC licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-api-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+    <name>Maven API Plugin</name>
+
+    <description>Maven plugin which creates, builds and installs an RESTful API module</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-esb-api-plugin/src/main/java/org/wso2/maven/api/RESTAPIMojo.java
+++ b/wso2-esb-api-plugin/src/main/java/org/wso2/maven/api/RESTAPIMojo.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.api;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Prepare an artifact to be installed in the local Maven repository
+ *
+ * @goal package-api
+ */
+public class RESTAPIMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${deploy-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${deploy-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    private File destFolder;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            } else {
+                String[] fileNameSplit = (artifact.getName().split("\\."));
+                String extension = fileNameSplit[fileNameSplit.length - 1];
+                String fileNameWithoutExtension = "";
+                if (artifact.getName().indexOf(".") > 0) {
+                    fileNameWithoutExtension = artifact.getName().substring(0, artifact.getName().lastIndexOf("."));
+                }
+
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result
+                    + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+
+}

--- a/wso2-esb-api-plugin/src/main/java/org/wso2/maven/api/RESTAPIPOMGenMojo.java
+++ b/wso2-esb-api-plugin/src/main/java/org/wso2/maven/api/RESTAPIPOMGenMojo.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.api;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class RESTAPIPOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private MavenProject mavenModuleProject;
+
+    private static final String ARTIFACT_TYPE = "synapse/api";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-endpoint-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File sequenceArtifact = processTokenReplacement(artifact);
+        if (sequenceArtifact == null) {
+            sequenceArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(sequenceArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject,
+                MavenConstants.WSO2_MAVEN_GROUPID, "wso2-esb-api-plugin",
+                WSO2MavenPluginConstantants.WSO2_ESB_API_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-api-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-api-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-proxy-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-api-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-api-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-proxy-plugin</id>
+    <resources>
+        <resource>src/main/resources/sample/sample-proxy.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-api-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-api-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,61 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/api</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-api-plugin:package-api</package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy
+                            </deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/api</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/api</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-api-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-api-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/proxy-service</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-proxy-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/proxyservice/proxyservice.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-api-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-proxy.xml
+++ b/wso2-esb-api-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-proxy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="${artifactId}" statistics="disable" trace="disable" transports="http,https">
+    <target>
+        <inSequence>
+            <log category="INFO" level="full" separator=",">
+                <property name="MESSAGE" value="Sending Request"/>
+            </log>
+        </inSequence>
+    </target>
+</proxy>

--- a/wso2-esb-connector-plugin/pom.xml
+++ b/wso2-esb-connector-plugin/pom.xml
@@ -1,0 +1,170 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-connector-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Maven ESB Connector Plugin</name>
+
+    <description>Maven plugin which creates and builds Connector artifacts</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${org.apache.maven.plugin.testing.harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-esb-connector-plugin/src/main/java/org/wso2/maven/plugin/connector/ConnectorMojo.java
+++ b/wso2-esb-connector-plugin/src/main/java/org/wso2/maven/plugin/connector/ConnectorMojo.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.connector;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is the Maven Mojo used for connector resources to be copied to the output directory in the resource-process
+ * phase.
+ *
+ * @goal package-connector
+ */
+public class ConnectorMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${package-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${package-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        File destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) {
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) {
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "." + extension;
+            } else {
+                newPath = destFolder.getAbsolutePath() + File.separator + artifact.getName();
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " + result.getName()
+                    + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+
+    }
+
+}

--- a/wso2-esb-connector-plugin/src/main/java/org/wso2/maven/plugin/connector/ConnectorPOMGenMojo.java
+++ b/wso2-esb-connector-plugin/src/main/java/org/wso2/maven/plugin/connector/ConnectorPOMGenMojo.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.connector;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a connector artifact
+ *
+ * @goal pom-gen
+ */
+public class ConnectorPOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    public MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    public MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    public File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    public File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    public File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    public String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private static final String ARTIFACT_TYPE = "synapse/lib";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        // Retrieving all the existing Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        // Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        // Mapping ESBArtifacts to C-App artifacts
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        // Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File connectorArtifact = artifact.getFile();
+        FileUtils.copyFile(connectorArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject, MavenConstants.WSO2_MAVEN_GROUPID,
+                "wso2-esb-connector-plugin", WSO2MavenPluginConstantants.WSO2_ESB_CONNECTOR_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        // add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-connector-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-connector-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,51 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/lib</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping
+            </implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-connector-plugin:package-connector</package>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/lib</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler
+            </implementation>
+            <configuration>
+                <type>synapse/lib</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>zip</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-connector-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-connector-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/lib</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>wso2-esb-connector-plugin</artifactId>
+                <version>1.0.0</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/wso2-esb-endpoint-plugin/pom.xml
+++ b/wso2-esb-endpoint-plugin/pom.xml
@@ -1,0 +1,196 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-endpoint-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Maven ESB Endpoint Plugin</name>
+
+    <description>Maven plugin which creates and builds Endpoint artifacts</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${org.apache.maven.plugin.testing.harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>run-its</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.4</version>
+                        <configuration>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>package</goal>
+                            </goals>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/wso2-esb-endpoint-plugin/src/main/java/org/wso2/maven/plugin/endpoint/EndpointMojo.java
+++ b/wso2-esb-endpoint-plugin/src/main/java/org/wso2/maven/plugin/endpoint/EndpointMojo.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.endpoint;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is the Maven Mojo used for endpoint resources to be copied to the output
+ * directory in the resource-process phase.
+ *
+ * @goal package-endpoint
+ */
+public class EndpointMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${package-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${package-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        File destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath =
+                        destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension +
+                                "." + extension;
+            } else {
+                newPath = destFolder.getAbsolutePath() + File.separator + artifact.getName();
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+
+    }
+
+}

--- a/wso2-esb-endpoint-plugin/src/main/java/org/wso2/maven/plugin/endpoint/EndpointPOMGenMojo.java
+++ b/wso2-esb-endpoint-plugin/src/main/java/org/wso2/maven/plugin/endpoint/EndpointPOMGenMojo.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.endpoint;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class EndpointPOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter default-value="${basedir}/pom.xml"
+     */
+    private File pomLocation;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    private MavenProject mavenModuleProject;
+
+    private static final String ARTIFACT_TYPE = "synapse/endpoint";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-endpoint-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File sequenceArtifact = processTokenReplacement(artifact);
+        if (sequenceArtifact == null) {
+            sequenceArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(sequenceArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils
+                .createPluginEntry(artifactMavenProject, MavenConstants.WSO2_MAVEN_GROUPID, "wso2-esb-endpoint-plugin",
+                        WSO2MavenPluginConstantants.WSO2_ESB_ENDPOINT_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+
+}

--- a/wso2-esb-endpoint-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-endpoint-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-endpoint-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-endpoint-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-endpoint-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-endpoint-plugin</id>
+    <resources>
+        <resource>src/main/resources/sample/sample-endpoint.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-endpoint-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-endpoint-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,57 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/endpoint</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-endpoint-plugin:package-endpoint</package>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/endpoint</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/endpoint</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-endpoint-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-endpoint-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/endpoint</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-endpoint-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/sample/sample-endpoint.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-endpoint-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-endpoint.xml
+++ b/wso2-esb-endpoint-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-endpoint.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<endpoint xmlns="http://ws.apache.org/ns/synapse" name="${artifactId}">
+    <default statistics="disable" trace="disable">
+        <timeout>
+            <duration>0</duration>
+            <action>discard</action>
+        </timeout>
+        <markForSuspension>
+            <retriesBeforeSuspension>0</retriesBeforeSuspension>
+            <retryDelay>0</retryDelay>
+        </markForSuspension>
+        <suspendOnFailure>
+            <initialDuration>0</initialDuration>
+            <maximumDuration>0</maximumDuration>
+            <progressionFactor>1.0</progressionFactor>
+        </suspendOnFailure>
+    </default>
+</endpoint>

--- a/wso2-esb-inboundendpoint-plugin/pom.xml
+++ b/wso2-esb-inboundendpoint-plugin/pom.xml
@@ -1,0 +1,151 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-inboundendpoint-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+    <name>Maven Inbound Endpoint Plugin</name>
+
+    <description>Maven plugin which creates, builds and installs an inbound endpoint module</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-esb-inboundendpoint-plugin/src/main/java/org/wso2/maven/inboundendpoint/InboundEndpointMojo.java
+++ b/wso2-esb-inboundendpoint-plugin/src/main/java/org/wso2/maven/inboundendpoint/InboundEndpointMojo.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.inboundendpoint;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Prepare an artifact to be installed in the local Maven repository
+ *
+ * @goal package-inbound-endpoint
+ */
+public class InboundEndpointMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${deploy-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${deploy-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    private File destFolder;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if user gives a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if user provides the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "." + extension;
+            } else {
+                newPath = destFolder.getAbsolutePath() + File.separator + artifact.getName();
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " + result.getName()
+                    + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+
+}

--- a/wso2-esb-inboundendpoint-plugin/src/main/java/org/wso2/maven/inboundendpoint/InboundEndpointPOMGenMojo.java
+++ b/wso2-esb-inboundendpoint-plugin/src/main/java/org/wso2/maven/inboundendpoint/InboundEndpointPOMGenMojo.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.inboundendpoint;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact from
+ * the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class InboundEndpointPOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when
+     * creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        // Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        // Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        // Mapping ESBArtifacts to C-App artifacts so that we can reuse the
+        // maven-endpoint-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), MavenConstants.ARTIFACT_XML_NAME));
+            mappedArtifacts.add(artifact);
+        }
+        // Calling the process artifacts method of super type to continue the
+        // sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File sequenceArtifact = processTokenReplacement(artifact);
+        if (sequenceArtifact == null) {
+            sequenceArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(sequenceArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject, MavenConstants.WSO2_MAVEN_GROUPID,
+                "wso2-esb-inboundendpoint-plugin",
+                WSO2MavenPluginConstantants.WSO2_ESB_INBOUND_ENDPOINT_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        // add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, MavenConstants.ARTIFACT_TAG);
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return MavenConstants.INBOUND_ENDPOINT_ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-inboundendpoint-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-inboundendpoint-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-inboundendpoint-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-inboundendpoint-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-inboundendpoint-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-inboundendpoint-plugin</id>
+    <resources>
+        <resource>src/main/resources/sample/sample-inboundendpoint.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-inboundendpoint-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-inboundendpoint-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,61 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/inbound-endpoint</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-inboundendpoint-plugin:package-inbound-endpoint</package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy
+                            </deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/inbound-endpoint</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/inbound-endpoint</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-inboundendpoint-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-inboundendpoint-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/inbound-endpoint</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-inboundendpoint-plugin</artifactId>
+                <version>1.0.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/inboundendpoint/inboundendpoint.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-inboundendpoint-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-inboundendpoint.xml
+++ b/wso2-esb-inboundendpoint-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-inboundendpoint.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<inboundEndpoint name="${artifactId}" onError="Sequence"
+                 protocol="http" sequence="Sequence" suspend="false"
+                 xmlns="http://ws.apache.org/ns/synapse">
+    <parameters>
+        <parameter name="api.dispatching.enabled">false</parameter>
+    </parameters>
+</inboundEndpoint>

--- a/wso2-esb-localentry-plugin/pom.xml
+++ b/wso2-esb-localentry-plugin/pom.xml
@@ -1,0 +1,196 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-localentry-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Maven ESB Local Entry Plugin</name>
+
+    <description>Maven plugin which creates and builds Local Entry artifacts</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${org.apache.maven.plugin.testing.harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>run-its</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.4</version>
+                        <configuration>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>package</goal>
+                            </goals>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/wso2-esb-localentry-plugin/src/main/java/org/wso2/maven/plugin/localentry/LocalEntryMojo.java
+++ b/wso2-esb-localentry-plugin/src/main/java/org/wso2/maven/plugin/localentry/LocalEntryMojo.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.localentry;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is the Maven Mojo used for localentry resources to be copied to the output
+ * directory in the resource-process phase.
+ *
+ * @goal package-localentry
+ */
+public class LocalEntryMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${package-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${package-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        File destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath =
+                        destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension +
+                                "." + extension;
+            } else {
+                newPath = destFolder.getAbsolutePath() + File.separator + artifact.getName();
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+
+    }
+
+}

--- a/wso2-esb-localentry-plugin/src/main/java/org/wso2/maven/plugin/localentry/LocalEntryPOMGenMojo.java
+++ b/wso2-esb-localentry-plugin/src/main/java/org/wso2/maven/plugin/localentry/LocalEntryPOMGenMojo.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.localentry;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class LocalEntryPOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    private MavenProject mavenModuleProject;
+
+    private static final String ARTIFACT_TYPE = "synapse/local-entry";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-endpoint-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File sequenceArtifact = processTokenReplacement(artifact);
+        if (sequenceArtifact == null) {
+            sequenceArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(sequenceArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils
+                .createPluginEntry(artifactMavenProject, MavenConstants.WSO2_MAVEN_GROUPID,
+                        "wso2-esb-localentry-plugin",
+                        WSO2MavenPluginConstantants.WSO2_ESB_LOCAL_ENTRY_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-localentry-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-localentry-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-localentry-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/localentry</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-localentry-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-localentry-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-localentry-plugin</id>
+    <resources>
+        <resource>src/main/resources/localentry/localentry.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-localentry-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-localentry-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,57 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/local-entry</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-localentry-plugin:package-localentry</package>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/local-entry</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/local-entry</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-localentry-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-localentry-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/local-entry</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-localentry-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/localentry/localentry.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-localentry-plugin/src/main/resources/archetype-resources/src/main/resources/localentry/localentry.xml
+++ b/wso2-esb-localentry-plugin/src/main/resources/archetype-resources/src/main/resources/localentry/localentry.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<localEntry xmlns="http://ws.apache.org/ns/synapse" key="localEntry">template</localEntry>

--- a/wso2-esb-messageprocessor-plugin/pom.xml
+++ b/wso2-esb-messageprocessor-plugin/pom.xml
@@ -1,0 +1,157 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-messageprocessor-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+    <name>Maven MessageProcessor Plugin</name>
+
+    <description>Maven plugin which creates, builds and installs a MessageProcessor module</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${org.apache.maven.plugin.testing.harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-esb-messageprocessor-plugin/src/main/java/org/wso2/maven/messageprocessor/MessageProcessorMojo.java
+++ b/wso2-esb-messageprocessor-plugin/src/main/java/org/wso2/maven/messageprocessor/MessageProcessorMojo.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.messageprocessor;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Prepare an artifact to be installed in the local Maven repository
+ *
+ * @goal package-messageprocessor
+ */
+public class MessageProcessorMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${deploy-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${deploy-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    private File destFolder;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            } else {
+                String[] fileNameSplit = (artifact.getName().split("\\."));
+                String extension = fileNameSplit[fileNameSplit.length - 1];
+                String fileNameWithoutExtension = "";
+                if (artifact.getName().indexOf(".") > 0) {
+                    fileNameWithoutExtension = artifact.getName().substring(0, artifact.getName().lastIndexOf("."));
+                }
+
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result
+                    + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+
+}

--- a/wso2-esb-messageprocessor-plugin/src/main/java/org/wso2/maven/messageprocessor/MessageProcessorPOMGenMojo.java
+++ b/wso2-esb-messageprocessor-plugin/src/main/java/org/wso2/maven/messageprocessor/MessageProcessorPOMGenMojo.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.messageprocessor;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a message-processor artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class MessageProcessorPOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private static final String ARTIFACT_TYPE = "synapse/message-processors";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File messageProcessorArtifact = processTokenReplacement(artifact);
+        if (messageProcessorArtifact == null) {
+            messageProcessorArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(messageProcessorArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject,
+                MavenConstants.WSO2_MAVEN_GROUPID, "wso2-esb-messageprocessor-plugin",
+                WSO2MavenPluginConstantants.WSO2_ESB_MESSAGE_PROCESSOR_PLUGIN_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-messageprocessor-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-messageprocessor-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="wso2-esb-messageprocessor-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-messageprocessor-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-messageprocessor-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>wso2-esb-messageprocessor-plugin</id>
+    <resources>
+        <resource>src/main/resources/message-processors/messageprocessor.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-messageprocessor-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-messageprocessor-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,61 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/message-processors</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-messageprocessor-plugin:package-messageprocessor</package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy
+                            </deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/message-processors</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/message-processors</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-messageprocessor-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-messageprocessor-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/message-processors</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>wso2-esb-messageprocessor-plugin</artifactId>
+                <version>1.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/sample/message-processors/messageprocessor.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-messageprocessor-plugin/src/main/resources/archetype-resources/src/main/resources/sample/message-processors/messageprocessor.xml
+++ b/wso2-esb-messageprocessor-plugin/src/main/resources/archetype-resources/src/main/resources/sample/message-processors/messageprocessor.xml
@@ -1,0 +1,4 @@
+<messageProcessor xmlns="http://ws.apache.org/ns/synapse"
+                  class="org.apache.synapse.message.processors.forward.ScheduledMessageForwardingProcessor"
+                  name="messageprocessor" messageStore="messagestore">
+</messageProcessor>

--- a/wso2-esb-messagestore-plugin/pom.xml
+++ b/wso2-esb-messagestore-plugin/pom.xml
@@ -1,0 +1,151 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-messagestore-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+    <name>Maven MessageStore Plugin</name>
+
+    <description>Maven plugin which creates, builds and installs a MessageStore module</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-esb-messagestore-plugin/src/main/java/org/wso2/maven/messagestore/SynapseMessageStoreMojo.java
+++ b/wso2-esb-messagestore-plugin/src/main/java/org/wso2/maven/messagestore/SynapseMessageStoreMojo.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.messagestore;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Prepare an artifact to be installed in the local Maven repository
+ *
+ * @goal package-messagestore
+ */
+public class SynapseMessageStoreMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${deploy-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${deploy-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    private File destFolder;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            } else {
+                String[] fileNameSplit = (artifact.getName().split("\\."));
+                String extension = fileNameSplit[fileNameSplit.length - 1];
+                String fileNameWithoutExtension = "";
+                if (artifact.getName().indexOf(".") > 0) {
+                    fileNameWithoutExtension = artifact.getName().substring(0, artifact.getName().lastIndexOf("."));
+                }
+
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result
+                    + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+
+}

--- a/wso2-esb-messagestore-plugin/src/main/java/org/wso2/maven/messagestore/SynapseMessageStorePOMGenMojo.java
+++ b/wso2-esb-messagestore-plugin/src/main/java/org/wso2/maven/messagestore/SynapseMessageStorePOMGenMojo.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.messagestore;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a message-store artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class SynapseMessageStorePOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private static final String ARTIFACT_TYPE = "synapse/message-store";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-endpoint-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File messageStoreArtifact = processTokenReplacement(artifact);
+        if (messageStoreArtifact == null) {
+            messageStoreArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(messageStoreArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject,
+                MavenConstants.WSO2_MAVEN_GROUPID, "wso2-esb-messagestore-plugin",
+                WSO2MavenPluginConstantants.WSO2_ESB_MESSAGE_STORE_PLUGIN_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-messagestore-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-messagestore-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="wso2-esb-messagestore-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-messagestore-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-messagestore-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>wso2-esb-messagestore-plugin</id>
+    <resources>
+        <resource>src/main/resources/message-stores/messagestore.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-messagestore-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-messagestore-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,61 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/message-store</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-messagestore-plugin:package-messagestore</package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy
+                            </deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/message-store</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/message-store</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-messagestore-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-messagestore-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/message-store</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>wso2-esb-messagestore-plugin</artifactId>
+                <version>1.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/message-stores/messagestore.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-messagestore-plugin/src/main/resources/archetype-resources/src/main/resources/sample/message-stores/messagestore.xml
+++ b/wso2-esb-messagestore-plugin/src/main/resources/archetype-resources/src/main/resources/sample/message-stores/messagestore.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<messageStore xmlns="http://ws.apache.org/ns/synapse"
+              name="messagestore" class="org.apache.synapse.message.store.InMemoryMessageStore"/>

--- a/wso2-esb-metadata-plugin/src/main/java/org/wso2/maven/metadata/MetadataPOMGenMojo.java
+++ b/wso2-esb-metadata-plugin/src/main/java/org/wso2/maven/metadata/MetadataPOMGenMojo.java
@@ -17,11 +17,6 @@
  */
 package org.wso2.maven.metadata;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -33,8 +28,15 @@ import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
 import org.wso2.maven.capp.model.Artifact;
 import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
 import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
 import org.wso2.maven.esb.ESBArtifact;
 import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This is the Maven Mojo used for generating a pom for a sequence artifact
@@ -133,7 +135,8 @@ public class MetadataPOMGenMojo extends AbstractPOMGenMojo {
 
     protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
         Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject,
-                "org.wso2.maven", "wso2-esb-metadata-plugin", "5.2.31", true);
+                MavenConstants.WSO2_MAVEN_GROUPID, "wso2-esb-metadata-plugin",
+                WSO2MavenPluginConstantants.WSO2_ESB_METADATA_PLUGIN_VERSION, true);
         Xpp3Dom configuration = (Xpp3Dom)plugin.getConfiguration();
         //add configuration
         Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration,"artifact");

--- a/wso2-esb-proxy-plugin/pom.xml
+++ b/wso2-esb-proxy-plugin/pom.xml
@@ -1,0 +1,151 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-proxy-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+    <name>Maven Proxy Plugin</name>
+
+    <description>Maven plugin which creates, builds and installs a proxy service module</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-esb-proxy-plugin/src/main/java/org/wso2/maven/proxy/ProxyServiceMojo.java
+++ b/wso2-esb-proxy-plugin/src/main/java/org/wso2/maven/proxy/ProxyServiceMojo.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.proxy;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Prepare an artifact to be installed in the local Maven repository
+ *
+ * @goal package-proxy
+ */
+public class ProxyServiceMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${deploy-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${deploy-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    private File destFolder;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName()
+                        .split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator
+                        + fileNameWithoutExtension + "." + extension;
+            } else {
+                newPath = destFolder.getAbsolutePath() + File.separator
+                        + artifact.getName();
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result
+                    + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+
+}

--- a/wso2-esb-proxy-plugin/src/main/java/org/wso2/maven/proxy/ProxyServicePOMGenMojo.java
+++ b/wso2-esb-proxy-plugin/src/main/java/org/wso2/maven/proxy/ProxyServicePOMGenMojo.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.proxy;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class ProxyServicePOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private MavenProject mavenModuleProject;
+
+    private static final String ARTIFACT_TYPE = "synapse/proxy-service";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-endpoint-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            // artifact.setVersion(this.getProject().getVersion());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File sequenceArtifact = processTokenReplacement(artifact);
+        if (sequenceArtifact == null) {
+            sequenceArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(sequenceArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin =
+                CAppMavenUtils.createPluginEntry(artifactMavenProject, MavenConstants.WSO2_MAVEN_GROUPID,
+                        "wso2-esb-proxy-plugin",
+                        WSO2MavenPluginConstantants.WSO2_ESB_PROXY_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-proxy-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-proxy-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-proxy-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-proxy-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-proxy-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-proxy-plugin</id>
+    <resources>
+        <resource>src/main/resources/sample/sample-proxy.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-proxy-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-proxy-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,61 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/proxy-service</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-proxy-plugin:package-proxy</package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy
+                            </deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/proxy-service</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/proxy-service</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-proxy-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-proxy-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/proxy-service</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-proxy-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/proxyservice/proxyservice.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-proxy-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-proxy.xml
+++ b/wso2-esb-proxy-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-proxy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="${artifactId}" statistics="disable" trace="disable" transports="http,https">
+    <target>
+        <inSequence>
+            <log category="INFO" level="full" separator=",">
+                <property name="MESSAGE" value="Sending Request"/>
+            </log>
+        </inSequence>
+    </target>
+</proxy>

--- a/wso2-esb-sequence-plugin/pom.xml
+++ b/wso2-esb-sequence-plugin/pom.xml
@@ -1,0 +1,196 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-sequence-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>Maven ESB Sequence Plugin</name>
+
+    <description>Maven plugin which creates and builds Sequence artifacts</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${org.apache.maven.plugin.testing.harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>run-its</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.4</version>
+                        <configuration>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>package</goal>
+                            </goals>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/wso2-esb-sequence-plugin/src/main/java/org/wso2/maven/plugin/sequence/SequenceMojo.java
+++ b/wso2-esb-sequence-plugin/src/main/java/org/wso2/maven/plugin/sequence/SequenceMojo.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.sequence;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is the Maven Mojo used for endpoint resources to be copied to the output
+ * directory in the resource-process phase.
+ *
+ * @goal package-sequence
+ */
+public class SequenceMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${package-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${package-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        File destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath =
+                        destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension +
+                                "." + extension;
+            } else {
+                newPath = destFolder.getAbsolutePath() + File.separator + artifact.getName();
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+
+    }
+
+}

--- a/wso2-esb-sequence-plugin/src/main/java/org/wso2/maven/plugin/sequence/SequencePOMGenMojo.java
+++ b/wso2-esb-sequence-plugin/src/main/java/org/wso2/maven/plugin/sequence/SequencePOMGenMojo.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.sequence;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class SequencePOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    public MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    public MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    public File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    public File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    public File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    public String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private static final String ARTIFACT_TYPE = "synapse/sequence";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-sequence-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File sequenceArtifact = processTokenReplacement(artifact);
+        if (sequenceArtifact == null) {
+            sequenceArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(sequenceArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils
+                .createPluginEntry(artifactMavenProject, MavenConstants.WSO2_MAVEN_GROUPID, "wso2-esb-sequence-plugin",
+                        WSO2MavenPluginConstantants.WSO2_ESB_SEQUENCE_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-sequence-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-sequence-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-sequence-plugin">
+    <requiredProperties>
+        <requiredProperty key="testParam">
+            <defaultValue>testValue</defaultValue>
+        </requiredProperty>
+    </requiredProperties>
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-sequence-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-sequence-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-sequence-plugin</id>
+    <resources>
+        <resource>src/main/resources/sample/sample-sequence.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-sequence-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-sequence-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,57 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/sequence</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-sequence-plugin:package-sequence</package>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/sequence</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/sequence</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-sequence-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-sequence-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/sequence</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-sequence-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/sample/sample-sequence.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-sequence-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-sequence.xml
+++ b/wso2-esb-sequence-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-sequence.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence xmlns="http://ws.apache.org/ns/synapse" name="${artifactId}"/>

--- a/wso2-esb-synapse-plugin/pom.xml
+++ b/wso2-esb-synapse-plugin/pom.xml
@@ -1,0 +1,201 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-synapse-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+
+    <name>WSO2 ESB Synapse Configuration Plugin</name>
+
+    <description>Maven plugin which creates and builds Synapse configuration artifacts</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${org.apache.maven.plugin.testing.harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io.wso2</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons.io.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>run-its</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <version>1.4</version>
+                        <configuration>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <pomIncludes>
+                                <pomInclude>*/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <postBuildHookScript>verify</postBuildHookScript>
+                            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                            <goals>
+                                <goal>clean</goal>
+                                <goal>package</goal>
+                            </goals>
+                            <settingsFile>src/it/settings.xml</settingsFile>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/SynapseMojo.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/SynapseMojo.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is the Maven Mojo used for synapse configuration resource to be copied to the output
+ * directory in the resource-process phase.
+ *
+ * @goal package-synapse
+ */
+public class SynapseMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${package-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${package-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${package-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        File destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath =
+                        destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension +
+                                "." + extension;
+            } else {
+                newPath = destFolder.getAbsolutePath() + File.separator + artifact.getName();
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/SynapsePOMGenMojo.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/SynapsePOMGenMojo.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class SynapsePOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    public MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    public MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    public File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    public File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    public File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    public String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private static final String ARTIFACT_TYPE = "synapse/configuration";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-sequence-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(this.getProject().getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File synapseArtifact = processTokenReplacement(artifact);
+        if (synapseArtifact == null) {
+            synapseArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(synapseArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin =
+                CAppMavenUtils.createPluginEntry(artifactMavenProject, MavenConstants.WSO2_MAVEN_GROUPID,
+                        "wso2-esb-synapse-plugin",
+                        WSO2MavenPluginConstantants.WSO2_ESB_SYNAPSE_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/AbstractSynapseDependentArtifactExporter.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/AbstractSynapseDependentArtifactExporter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMAbstractFactory;
+import org.apache.axiom.om.OMDocument;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMFactory;
+import org.apache.commons.io.IOUtils;
+import org.apache.maven.project.MavenProject;
+import org.wso2.maven.capp.model.CAppArtifactDependency;
+import org.wso2.maven.core.utils.MavenUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+/**
+ * An abstract implementation of {@link SynapseDependentArtifactExporter}.
+ */
+public abstract class AbstractSynapseDependentArtifactExporter implements SynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    public CAppArtifactDependency export(OMElement artifactDefinition, CAppArtifactDependency synapseArtifactClone,
+                                         File workDir)
+            throws Exception {
+        // Create the temporary directory.
+        workDir.mkdirs();
+        // Serialize the sequence definition.
+        String artifactName = getArtifactName(artifactDefinition);
+        File artifactContentFile = new File(workDir, String.format("%s.xml", artifactName));
+        FileOutputStream fos = null;
+        try {
+            fos = new FileOutputStream(artifactContentFile);
+            OMFactory omFactory = OMAbstractFactory.getOMFactory();
+            OMDocument omDocument = omFactory.createOMDocument();
+            omDocument.addChild(artifactDefinition);
+            omDocument.serialize(fos);
+        } finally {
+            IOUtils.closeQuietly(fos);
+        }
+
+        // Create the sequence artifact.
+        MavenProject dummyMavenProject = MavenUtils
+                .createMavenProject(synapseArtifactClone.getcAppArtifact().getProject().getGroupId(), artifactName,
+                        synapseArtifactClone.getVersion(), getArtifactType());
+        CAppArtifactDependency cAppArtifactDependency =
+                new CAppArtifactDependency(dummyMavenProject, getArtifactType(), synapseArtifactClone.getServerRole());
+        cAppArtifactDependency.setDummyDependency(true);
+        cAppArtifactDependency.setArtifactFiles(new File[]{artifactContentFile});
+        cAppArtifactDependency.getcAppArtifact().setFile(artifactContentFile.getName());
+        return cAppArtifactDependency;
+    }
+
+    /**
+     * Determines the name of the artifact which is to be exported.
+     *
+     * @param artifactDefinition serialized form of the artifact.
+     * @return artifact name.
+     */
+    protected abstract String getArtifactName(OMElement artifactDefinition);
+
+    /**
+     * Determines the type of the artifact to be exported.
+     *
+     * @return artifact type identifier string.
+     */
+    protected abstract String getArtifactType();
+
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/EndPointArtifactExporter.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/EndPointArtifactExporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import javax.xml.namespace.QName;
+
+/**
+ * {@link SynapseDependentArtifactExporter} corresponding to <endpoint/> tag.
+ */
+public class EndPointArtifactExporter extends AbstractSynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactName(OMElement artifactDefinition) {
+
+        return artifactDefinition.getAttributeValue(new QName("name"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactType() {
+
+        return "synapse/endpoint";
+    }
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/LocalEntryArtifactExporter.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/LocalEntryArtifactExporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import javax.xml.namespace.QName;
+
+/**
+ * {@link SynapseDependentArtifactExporter} corresponding to <localEntry/> tag.
+ */
+public class LocalEntryArtifactExporter extends AbstractSynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactName(OMElement artifactDefinition) {
+
+        return artifactDefinition.getAttributeValue(new QName("key"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactType() {
+
+        return "synapse/local-entry";
+    }
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/ProxyServiceArtifactExporter.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/ProxyServiceArtifactExporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import javax.xml.namespace.QName;
+
+/**
+ * {@link SynapseDependentArtifactExporter} corresponding to <localEntry/> tag.
+ */
+public class ProxyServiceArtifactExporter extends AbstractSynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactName(OMElement artifactDefinition) {
+
+        return artifactDefinition.getAttributeValue(new QName("name"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactType() {
+
+        return "synapse/proxy-service";
+    }
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SequenceArtifactExporter.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SequenceArtifactExporter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import javax.xml.namespace.QName;
+
+/**
+ * {@link SynapseDependentArtifactExporter} corresponding to <sequence/> tag.
+ */
+public class SequenceArtifactExporter extends AbstractSynapseDependentArtifactExporter {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactName(OMElement artifactDefinition) {
+
+        return artifactDefinition.getAttributeValue(new QName("name"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected String getArtifactType() {
+
+        return "synapse/sequence";
+    }
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseArtifactBundleCreator.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseArtifactBundleCreator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.io.IOUtils;
+import org.wso2.developerstudio.eclipse.utils.file.FileUtils;
+import org.wso2.maven.capp.model.CAppArtifactDependency;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A specialization of {@link ArtifactBundleCreator} used to explode synapse
+ * configuration artifacts into multiple artifacts at car generation.
+ */
+public class SynapseArtifactBundleCreator {
+
+    /**
+     * Dependent artifact exporter factory.
+     */
+    private SynapseDependentArtifactExporterFactory exporterFactory;
+
+    private CAppArtifactDependency artifact;
+
+    /**
+     * Creates a new {@link SynapseArtifactBundleCreator} instance.
+     *
+     * @param artifact synapse configuration artifact.
+     */
+    public SynapseArtifactBundleCreator(CAppArtifactDependency artifact) {
+
+        setArtifact(artifact);
+        exporterFactory = SynapseDependentArtifactExporterFactory.getInstance();
+    }
+
+    /**
+     * Exports any dependent artifacts that can be extracted from this synapse
+     * configuration artifacts.
+     *
+     * @param synapseXmlFile       synapse.xml file.
+     * @param synapseArtifactClone clone of the original synapse artifact.
+     * @throws Exception if an error is encountered while performing the explode
+     *                   operation.
+     */
+    public List<CAppArtifactDependency> exportDependentArtifacts(File synapseXmlFile,
+                                                                 CAppArtifactDependency synapseArtifactClone)
+            throws Exception {
+
+        FileInputStream fis = null;
+        List<CAppArtifactDependency> list = new ArrayList<CAppArtifactDependency>();
+        try {
+            // Parse the synapse.xml file into an OMDocument.
+            fis = new FileInputStream(synapseXmlFile);
+            StAXOMBuilder builder = new StAXOMBuilder(fis);
+            OMElement documentElement = builder.getDocumentElement();
+            documentElement.build();
+
+            // Iterate through all the top level elements looking for sub
+            // artifacts that can be extracted.
+            Iterator<?> iter = documentElement.getChildElements();
+            while (iter.hasNext()) {
+                OMElement childElement = (OMElement) iter.next();
+                SynapseDependentArtifactExporter exporter = exporterFactory.getExporter(childElement.getLocalName());
+                if (null != exporter) {
+                    // Create a working directory only if we have at least one
+                    // exporter.
+                    File workDir = FileUtils.createTempDirectory();
+                    try {
+                        CAppArtifactDependency dependency =
+                                exporter.export(childElement, synapseArtifactClone, workDir);
+                        if (dependency != null) {
+                            list.add(dependency);
+                        }
+                    } catch (Exception ex) {
+                    }
+                }
+            }
+        } finally {
+            // Close file input stream.
+            IOUtils.closeQuietly(fis);
+        }
+        return list;
+    }
+
+    public void setArtifact(CAppArtifactDependency artifact) {
+
+        this.artifact = artifact;
+    }
+
+    public CAppArtifactDependency getArtifact() {
+
+        return artifact;
+    }
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseDependentArtifactExporter.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseDependentArtifactExporter.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+import org.wso2.maven.capp.model.CAppArtifactDependency;
+
+import java.io.File;
+
+/**
+ * Interface for synapse dependent artifact exporters.
+ */
+public interface SynapseDependentArtifactExporter {
+
+    /**
+     * Exports the specified dependent artifact into the directory specified by
+     * <strong>contentLocation</strong> argument. This method will update the
+     * <strong>synapseArtifact</strong> to reflect the newly added dependency.
+     *
+     * @param artifactDefinition   artifact definition {@link OMElement}.
+     * @param synapseArtifactClone clone of the synapse artifact from which this dependent
+     *                             artifact was extracted from.
+     * @param workDir              temporary working directory.
+     * @throws Exception if an error occurs while exporting the artifact.
+     */
+    CAppArtifactDependency export(OMElement artifactDefinition, CAppArtifactDependency synapseArtifactClone,
+                                  File workDir)
+            throws Exception;
+
+}

--- a/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseDependentArtifactExporterFactory.java
+++ b/wso2-esb-synapse-plugin/src/main/java/org/wso2/maven/plugin/synapse/utils/SynapseDependentArtifactExporterFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.plugin.synapse.utils;
+
+import org.apache.axiom.om.OMElement;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A singleton factory for creating {@link SynapseDependentArtifactExporter}
+ * instances.
+ */
+public class SynapseDependentArtifactExporterFactory {
+
+    /**
+     * Singleton factory.
+     */
+    private static SynapseDependentArtifactExporterFactory singleton;
+
+    /**
+     * A map of {@link OMElement} local name to corresponding {@link SynapseDependentArtifactExporter} instances.
+     */
+    private Map<String, SynapseDependentArtifactExporter> localNameToExportersMap;
+
+    /**
+     * Private constructor.
+     */
+    private SynapseDependentArtifactExporterFactory() {
+
+        localNameToExportersMap = new HashMap<String, SynapseDependentArtifactExporter>();
+
+        // Initialize exporters.
+        localNameToExportersMap.put("sequence", new SequenceArtifactExporter());
+        localNameToExportersMap.put("endpoint", new EndPointArtifactExporter());
+        localNameToExportersMap.put("localEntry", new LocalEntryArtifactExporter());
+        localNameToExportersMap.put("proxy", new ProxyServiceArtifactExporter());
+    }
+
+    /**
+     * @return singleton factory instance.
+     */
+    public static final SynapseDependentArtifactExporterFactory getInstance() {
+
+        if (null == singleton) {
+            singleton = new SynapseDependentArtifactExporterFactory();
+        }
+
+        return singleton;
+    }
+
+    /**
+     * Returns the {@link SynapseDependentArtifactExporter} corresponding to the
+     * specified local name.
+     *
+     * @param localName local name of the {@link OMElement} which represents the
+     *                  serialized form of dependent artifact.
+     * @return {@link SynapseDependentArtifactExporter} corresponding to the
+     * specified local name or null if no exporter is found.
+     */
+    public SynapseDependentArtifactExporter getExporter(String localName) {
+
+        return localNameToExportersMap.get(localName);
+    }
+}

--- a/wso2-esb-synapse-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-synapse-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-sequence-plugin">
+    <requiredProperties>
+        <requiredProperty key="testParam">
+            <defaultValue>testValue</defaultValue>
+        </requiredProperty>
+    </requiredProperties>
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-synapse-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-synapse-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-sequence-plugin</id>
+    <resources>
+        <resource>src/main/resources/sample/sample-sequence.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-synapse-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-synapse-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,57 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/configuration</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-synapse-plugin:package-synapse</package>
+                            <install>org.apache.maven.plugins:maven-install-plugin:install</install>
+                            <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/configuration</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/configuration</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-synapse-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-synapse-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/sequence</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-sequence-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/sample/sample-sequence.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-synapse-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-sequence.xml
+++ b/wso2-esb-synapse-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-sequence.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sequence xmlns="http://ws.apache.org/ns/synapse" name="${artifactId}"/>

--- a/wso2-esb-task-plugin/pom.xml
+++ b/wso2-esb-task-plugin/pom.xml
@@ -1,0 +1,157 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-task-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+    <name>Maven Task Plugin</name>
+
+    <description>Maven plugin which creates, builds and installs a Task module</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${org.apache.maven.plugin.testing.harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-esb-task-plugin/src/main/java/org/wso2/maven/task/SynapseTaskMojo.java
+++ b/wso2-esb-task-plugin/src/main/java/org/wso2/maven/task/SynapseTaskMojo.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.task;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Prepare an artifact to be installed in the local Maven repository
+ *
+ * @goal package-task
+ */
+public class SynapseTaskMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${deploy-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${deploy-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    private File destFolder;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            } else {
+                String[] fileNameSplit = (artifact.getName().split("\\."));
+                String extension = fileNameSplit[fileNameSplit.length - 1];
+                String fileNameWithoutExtension = "";
+                if (artifact.getName().indexOf(".") > 0) {
+                    fileNameWithoutExtension = artifact.getName().substring(0, artifact.getName().lastIndexOf("."));
+                }
+
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result
+                    + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+
+}

--- a/wso2-esb-task-plugin/src/main/java/org/wso2/maven/task/SynapseTaskPOMGenMojo.java
+++ b/wso2-esb-task-plugin/src/main/java/org/wso2/maven/task/SynapseTaskPOMGenMojo.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.task;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class SynapseTaskPOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private static final String ARTIFACT_TYPE = "synapse/task";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-endpoint-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            artifact.setType(esbArtifact.getType());
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File taskArtifact = processTokenReplacement(artifact);
+        if (taskArtifact == null) {
+            taskArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(taskArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject,
+                MavenConstants.WSO2_MAVEN_GROUPID, "wso2-esb-task-plugin",
+                WSO2MavenPluginConstantants.WSO2_ESB_TASK_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-task-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-task-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-proxy-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-task-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-task-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-proxy-plugin</id>
+    <resources>
+        <resource>src/main/resources/sample/sample-proxy.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-task-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-task-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,61 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/task</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-task-plugin:package-task</package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy
+                            </deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/task</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/task</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-task-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-task-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/proxy-service</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-proxy-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/proxyservice/proxyservice.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-task-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-proxy.xml
+++ b/wso2-esb-task-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-proxy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="${artifactId}" statistics="disable" trace="disable" transports="http,https">
+    <target>
+        <inSequence>
+            <log category="INFO" level="full" separator=",">
+                <property name="MESSAGE" value="Sending Request"/>
+            </log>
+        </inSequence>
+    </target>
+</proxy>

--- a/wso2-esb-template-plugin/pom.xml
+++ b/wso2-esb-template-plugin/pom.xml
@@ -1,0 +1,151 @@
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <artifactId>maven-common-tools</artifactId>
+        <groupId>org.wso2.maven</groupId>
+        <version>5.2.42-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>wso2-esb-template-plugin</artifactId>
+    <version>5.2.42-SNAPSHOT</version>
+    <packaging>maven-plugin</packaging>
+    <name>Maven Template Plugin</name>
+
+    <description>Maven plugin which creates, builds and installs an ESB Template module</description>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>org.apache.maven.wagon</groupId>
+                <artifactId>wagon-ssh</artifactId>
+                <version>1.0-beta-6</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>biz.aQute</groupId>
+            <artifactId>bndlib</artifactId>
+            <version>${bndlib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.kxml</groupId>
+            <artifactId>kxml2</artifactId>
+            <version>${kxml2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.bundlerepository</artifactId>
+            <version>${org.apache.felix.bundlerepository.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${org.apache.felix.org.osgi.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.service.obr</artifactId>
+            <version>${org.apache.felix.org.osgi.service.obr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${org.apache.maven.project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>${org.apache.maven.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${org.apache.maven.plugin.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>${org.apache.maven.artifact.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-archiver</artifactId>
+            <version>${org.apache.maven.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact-manager</artifactId>
+            <version>${org.apache.maven.artifact.manager.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-settings</artifactId>
+            <version>${org.apache.maven.settings.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>${org.apache.maven.dependency.tree.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.wagon</groupId>
+            <artifactId>wagon-provider-api</artifactId>
+            <version>${org.apache.maven.wagon.provider.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>${plexus.container.default.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-archiver</artifactId>
+            <version>${plexus.archiver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+            <version>${plexus.utils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.capp</artifactId>
+            <version>${org.wso2.maven.capp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.maven</groupId>
+            <artifactId>org.wso2.maven.esb</artifactId>
+            <version>${org.wso2.maven.esb.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/wso2-esb-template-plugin/src/main/java/org/wso2/maven/template/ESBTemplateMojo.java
+++ b/wso2-esb-template-plugin/src/main/java/org/wso2/maven/template/ESBTemplateMojo.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.template;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Prepare an artifact to be installed in the local Maven repository
+ *
+ * @goal package-template
+ */
+public class ESBTemplateMojo extends AbstractMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the existing artifact
+     *
+     * @parameter expression="${deploy-file.artifact}"
+     * @required
+     */
+    private File artifact;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.extension}
+     */
+    private String extension;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter expression="${deploy-file.fileName}
+     */
+    private String fileName;
+
+    /**
+     * If the file should be archived
+     *
+     * @parameter expression="${deploy-file.enableArchive}" default-value=false
+     */
+    private boolean enableArchive;
+
+    private File destFolder;
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        destFolder = new File(project.getBuild().getDirectory());
+        String newPath = null;
+
+        if (fileName != null) { // if the user gave a name for the file
+            newPath = destFolder.getAbsolutePath() + File.separator + fileName;
+        } else {
+            if (extension != null) { // if the user provided the extension
+                String fileNameWithoutExtension = (artifact.getName().split("\\."))[0];
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            } else {
+                String[] fileNameSplit = (artifact.getName().split("\\."));
+                String extension = fileNameSplit[fileNameSplit.length - 1];
+                String fileNameWithoutExtension = "";
+                if (artifact.getName().indexOf(".") > 0) {
+                    fileNameWithoutExtension = artifact.getName().substring(0, artifact.getName().lastIndexOf("."));
+                }
+
+                newPath = destFolder.getAbsolutePath() + File.separator + fileNameWithoutExtension + "-"
+                        + project.getVersion() + "." + extension;
+            }
+        }
+
+        File result = new File(newPath);
+
+        if (!artifact.exists()) {
+            throw new MojoExecutionException(artifact.getAbsolutePath() + " doesn't exist.");
+        }
+
+        try {
+            FileUtils.copyFile(artifact, result);
+
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error when copying " + artifact.getName() + " to " +
+                    result.getName() + "\n" + e.getMessage());
+        }
+
+        if (result != null && result.exists()) {
+            project.getArtifact().setFile(result);
+        } else {
+            throw new MojoExecutionException(result
+                    + " is null or doesn't exist");
+        }
+
+        if (enableArchive) {
+            // TODO make the zip file
+        }
+    }
+
+}

--- a/wso2-esb-template-plugin/src/main/java/org/wso2/maven/template/ESBTemplatePOMGenMojo.java
+++ b/wso2-esb-template-plugin/src/main/java/org/wso2/maven/template/ESBTemplatePOMGenMojo.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.template;
+
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.codehaus.plexus.util.FileUtils;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.wso2.developerstudio.eclipse.utils.data.ITemporaryFileTag;
+import org.wso2.maven.capp.model.Artifact;
+import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
+import org.wso2.maven.capp.utils.CAppMavenUtils;
+import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
+import org.wso2.maven.esb.ESBArtifact;
+import org.wso2.maven.esb.utils.ESBMavenUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is the Maven Mojo used for generating a pom for a sequence artifact
+ * from the old CApp project structure
+ *
+ * @goal pom-gen
+ */
+public class ESBTemplatePOMGenMojo extends AbstractPOMGenMojo {
+
+    /**
+     * @parameter default-value="${project}"
+     */
+    private MavenProject project;
+
+    /**
+     * Maven ProjectHelper.
+     *
+     * @component
+     */
+    private MavenProjectHelper projectHelper;
+
+    /**
+     * The path of the location to output the pom
+     *
+     * @parameter expression="${project.build.directory}/artifacts"
+     */
+    private File outputLocation;
+
+    /**
+     * The resulting extension of the file
+     *
+     * @parameter
+     */
+    private File artifactLocation;
+
+    /**
+     * POM location for the module project
+     *
+     * @parameter expression="${project.build.directory}/pom.xml"
+     */
+    private File moduleProject;
+
+    /**
+     * Group id to use for the generated pom
+     *
+     * @parameter
+     */
+    private String groupId;
+
+    /**
+     * Comma separated list of "artifact_type=extension" to be used when creating dependencies for other capp artifacts
+     *
+     * @parameter
+     */
+    public String typeList;
+
+    private MavenProject mavenModuleProject;
+
+    private static final String ARTIFACT_TYPE = "synapse/template";
+
+    private List<ESBArtifact> retrieveArtifacts() {
+
+        return ESBMavenUtils.retrieveArtifacts(getArtifactLocation());
+    }
+
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        //Retrieving all the existing ESB Artifacts for the given Maven project
+        List<ESBArtifact> artifacts = retrieveArtifacts();
+
+        //Artifact list
+        List<Artifact> mappedArtifacts = new ArrayList<Artifact>();
+
+        //Mapping ESBArtifacts to C-App artifacts so that we can reuse the maven-endpoint-plugin
+        for (ESBArtifact esbArtifact : artifacts) {
+            Artifact artifact = new Artifact();
+            artifact.setName(esbArtifact.getName());
+            artifact.setVersion(esbArtifact.getVersion());
+            if (("synapse/sequenceTemplate".equals(esbArtifact.getType())) ||
+                    ("synapse/endpointTemplate".equals(esbArtifact.getType()))) {
+                artifact.setType("synapse/template");
+            } else {
+                artifact.setType(esbArtifact.getType());
+            }
+            artifact.setServerRole(esbArtifact.getServerRole());
+            artifact.setFile(esbArtifact.getFile());
+            artifact.setSource(new File(getArtifactLocation(), "artifact.xml"));
+            mappedArtifacts.add(artifact);
+        }
+        //Calling the process artifacts method of super type to continue the sequence.
+        super.processArtifacts(mappedArtifacts);
+
+    }
+
+    protected void copyResources(MavenProject project, File projectLocation, Artifact artifact) throws IOException {
+
+        ITemporaryFileTag newTag = org.wso2.developerstudio.eclipse.utils.file.FileUtils.createNewTempTag();
+        File sequenceArtifact = processTokenReplacement(artifact);
+        if (sequenceArtifact == null) {
+            sequenceArtifact = artifact.getFile();
+        }
+        FileUtils.copyFile(sequenceArtifact, new File(projectLocation, artifact.getFile().getName()));
+        newTag.clearAndEnd();
+    }
+
+    protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
+
+        Plugin plugin = CAppMavenUtils.createPluginEntry(artifactMavenProject,
+                MavenConstants.WSO2_MAVEN_GROUPID, "wso2-esb-template-plugin",
+                WSO2MavenPluginConstantants.WSO2_ESB_TEMPLATE_VERSION, true);
+        Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+        //add configuration
+        Xpp3Dom aritfact = CAppMavenUtils.createConfigurationNode(configuration, "artifact");
+        aritfact.setValue(artifact.getFile().getName());
+    }
+
+    protected String getArtifactType() {
+
+        return ARTIFACT_TYPE;
+    }
+}

--- a/wso2-esb-template-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wso2-esb-template-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archetype-descriptor name="maven-proxy-plugin">
+    <fileSets>
+        <fileSet filtered="true" encoding="UTF-8">
+            <directory>src/main/resources/sample</directory>
+        </fileSet>
+    </fileSets>
+</archetype-descriptor>

--- a/wso2-esb-template-plugin/src/main/resources/META-INF/maven/archetype.xml
+++ b/wso2-esb-template-plugin/src/main/resources/META-INF/maven/archetype.xml
@@ -1,0 +1,6 @@
+<archetype>
+    <id>maven-proxy-plugin</id>
+    <resources>
+        <resource>src/main/resources/sample/sample-proxy.xml</resource>
+    </resources>
+</archetype>

--- a/wso2-esb-template-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/wso2-esb-template-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,61 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+<component-set>
+    <components>
+        <component>
+            <role>org.apache.maven.lifecycle.mapping.LifecycleMapping</role>
+            <role-hint>synapse/template</role-hint>
+            <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
+            <configuration>
+                <lifecycles>
+                    <lifecycle>
+                        <id>default</id>
+                        <phases>
+                            <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources
+                            </process-resources>
+                            <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
+                            <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+                            </process-test-resources>
+                            <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
+                            <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>
+                            <package>org.wso2.maven:wso2-esb-template-plugin:package-template</package>
+                            <install>
+                                org.apache.maven.plugins:maven-install-plugin:install
+                            </install>
+                            <deploy>
+                                org.apache.maven.plugins:maven-deploy-plugin:deploy
+                            </deploy>
+                        </phases>
+                    </lifecycle>
+                </lifecycles>
+            </configuration>
+        </component>
+        <component>
+            <role>org.apache.maven.artifact.handler.ArtifactHandler</role>
+            <role-hint>synapse/template</role-hint>
+            <implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>
+            <configuration>
+                <type>synapse/template</type>
+                <includesDependencies>false</includesDependencies>
+                <extension>xml</extension>
+                <addedToClasspath>false</addedToClasspath>
+            </configuration>
+        </component>
+    </components>
+</component-set>

--- a/wso2-esb-template-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/wso2-esb-template-plugin/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>${groupId}</groupId>
+    <artifactId>${artifactId}</artifactId>
+    <version>${version}</version>
+    <packaging>synapse/proxy-service</packaging>
+    <name>${artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>maven-proxy-plugin</artifactId>
+                <version>2.1.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <artifact>src/main/resources/proxyservice/proxyservice.xml</artifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/wso2-esb-template-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-proxy.xml
+++ b/wso2-esb-template-plugin/src/main/resources/archetype-resources/src/main/resources/sample/sample-proxy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="${artifactId}" statistics="disable" trace="disable" transports="http,https">
+    <target>
+        <inSequence>
+            <log category="INFO" level="full" separator=",">
+                <property name="MESSAGE" value="Sending Request"/>
+            </log>
+        </inSequence>
+    </target>
+</proxy>

--- a/wso2-general-project-plugin/src/main/java/org/wso2/maven/registry/RegistryResourcePOMGenMojo.java
+++ b/wso2-general-project-plugin/src/main/java/org/wso2/maven/registry/RegistryResourcePOMGenMojo.java
@@ -26,6 +26,7 @@ import org.wso2.developerstudio.eclipse.utils.file.FileUtils;
 import org.wso2.maven.capp.model.Artifact;
 import org.wso2.maven.capp.mojo.AbstractPOMGenMojo;
 import org.wso2.maven.capp.utils.WSO2MavenPluginConstantants;
+import org.wso2.maven.core.utils.MavenConstants;
 import org.wso2.maven.core.utils.MavenUtils;
 import org.wso2.maven.registry.beans.RegistryCollection;
 import org.wso2.maven.registry.beans.RegistryElement;
@@ -270,7 +271,7 @@ public class RegistryResourcePOMGenMojo extends AbstractPOMGenMojo {
     }
 
     protected void addPlugins(MavenProject artifactMavenProject, Artifact artifact) {
-        Plugin plugin = MavenUtils.createPluginEntry(artifactMavenProject, "org.wso2.maven", "maven-registry-plugin",
+        Plugin plugin = MavenUtils.createPluginEntry(artifactMavenProject, MavenConstants.WSO2_MAVEN_GROUPID, "wso2-general-project-plugin",
                                                      WSO2MavenPluginConstantants.MAVEN_REGISTRY_PLUGIN_VERSION, true);
         Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
         //add configuration


### PR DESCRIPTION
## Purpose
The current released ESB artifacts related plugin version is 2.1.0. The source code of this version has been removed[1] after release 5.0.0. Since we need to exclude vulnerable log4j and perform a new release, this PR will bring back those plugins to the master branch

[1] - https://github.com/wso2/maven-tools/commit/3357ade292ef0272fc0da3f80028a37dff312e0a