### PR TITLE
Add wildcard support in file name / wso2-maven-json-merge-plugin

### DIFF
--- a/wso2-maven-json-merge-plugin/pom.xml
+++ b/wso2-maven-json-merge-plugin/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>gson</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Purpose
wso2-maven-json-merge-plugin cannot be used with wildcards on files name
Example :

```
<base>${project.basedir}/json/global.json</base>
<include>
    <param>${project.basedir}/json/override/*.json</param>
</include>
<target>${project.build.directory}/json/global.json</target>
```

Resolves issue #107 

## Goals
Implements a wildcard filter on param files

## Approach
Param files uses Apache commons-io WildcardFileFilter to retrieve all files matching with wildcard.
If no wirldcard is present on param, behaviour is still the same

## Release note
Add wildcard support in file name / wso2-maven-json-merge-plugin

## Documentation
N/A

## Training
N/A
