### PR TITLE
Fix for non-existing test folder, resulting in null listOfFiles

### DIFF
--- a/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/UnitTestCasesMojo.java
+++ b/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/UnitTestCasesMojo.java
@@ -173,10 +173,12 @@ public class UnitTestCasesMojo extends AbstractMojo {
             File folder = new File(testFolderPath);
             File[] listOfFiles = folder.listFiles();
 
-            for (File file : listOfFiles) {
-                String filename = file.getName();
-                if (filename.endsWith(Constants.XML_EXTENSION)) {
-                    fileNamesWithPaths.add(testFolderPath + filename);
+            if (listOfFiles != null) {
+                for (File file : listOfFiles) {
+                    String filename = file.getName();
+                    if (filename.endsWith(Constants.XML_EXTENSION)) {
+                        fileNamesWithPaths.add(testFolderPath + filename);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Purpose
> When the default test folder (in build-artifacts, since Integration Studio 8.2.0) is not present, the plugin throws an exception. However, it should just return that no test cases were found, similar to when the test folder does exist but is empty.
Fixes the issue #114 

## Approach
> Add a check to see if listOfFiles is not null before trying to read all files in listOfFiles.
