### PR TITLE
Remove additional suffix in CAPP name

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -436,7 +436,7 @@ class CAppHandler extends AbstractXMLDoc {
         OMElement artifactsElement = getElement(Constants.ARTIFACTS, Constants.EMPTY_STRING);
         OMElement artifactElement = getElement(Constants.ARTIFACT, Constants.EMPTY_STRING);
 
-        artifactElement = addAttribute(artifactElement, Constants.NAME, project.getArtifactId() + "CompositeExporter");
+        artifactElement = addAttribute(artifactElement, Constants.NAME, project.getArtifactId());
         artifactElement = addAttribute(artifactElement, Constants.VERSION, project.getVersion());
         artifactElement = addAttribute(artifactElement, Constants.TYPE, Constants.CAPP_TYPE);
         if (project.getProperties().containsKey(Constants.MAIN_SEQUENCE)) {


### PR DESCRIPTION

## Purpose
> Remove additional suffix in CAPP name to avoid confusion in Automation mode
