### PR TITLE
Fix datamapper schema generation && dmc bundling

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
@@ -218,6 +218,7 @@ public class DataMapperBundler {
         mojoInstance.logInfo("Bundle completed for data mapper: " + dataMapperName);
         Path bundledJsFilePath = Paths.get("." + File.separator
                 + Constants.TARGET_DIR_NAME + File.separator + "src" + File.separator + dataMapperName + ".dmc");
+        appendMapFunction(bundledJsFilePath.toString());
         copyGenerateDataMapperFile(bundledJsFilePath.toString(), dataMapper);
 
         removeSourceFiles();
@@ -470,7 +471,10 @@ public class DataMapperBundler {
                 "        filename: \"./src/" + dataMapperName + ".dmc\",\n" +
                 "        path: path.resolve(__dirname),\n" +
                 "        iife: false,\n" +
+                "        library: 'DataMapper', \n" +
+                "        libraryTarget: 'var',\n" +
                 "    },\n" +
+                "    mode: \"production\",\n" +
                 "};";
     
         try (FileWriter fileWriter = new FileWriter("." + File.separator + Constants.TARGET_DIR_NAME
@@ -478,6 +482,23 @@ public class DataMapperBundler {
             fileWriter.write(webPackConfigContent);
         } catch (IOException e) {
             throw new DataMapperException("Failed to create webpack.config.js file.", e);
+        }
+    }
+
+    /**
+     * Appends the function to call the mapFunction inside webpack bundled file.
+     *
+     * @param dmcPath The path to the data mapper configuration file.
+     */
+    private void appendMapFunction(String dmcPath) {
+        String mapFunction = "\n\nfunction mapFunction(input) {\n" +
+                "    return DataMapper.mapFunction(input);\n" +
+                "}\n";
+
+        try (FileWriter fileWriter = new FileWriter(dmcPath, true)) {
+            fileWriter.write(mapFunction);
+        } catch (IOException e) {
+            mojoInstance.logError("Failed to append map function to the bundled js file.");
         }
     }
 

--- a/vscode-car-plugin/src/main/resources/schemaGenerator.ts
+++ b/vscode-car-plugin/src/main/resources/schemaGenerator.ts
@@ -166,9 +166,9 @@ function generateJsonSchemaFromAST(ast: ts.SourceFile): any {
             if (ts.isTypeLiteralNode(member.type.elementType)) {
               processMembers(member.type.elementType.members, nestedSchema);
             }
-            parentSchema.properties[propertyName] = { type: "array", items: nestedSchema };
+            parentSchema.properties[propertyName] = { type: "array", items: [nestedSchema] };
           } else {
-            parentSchema.properties[propertyName] = { type: "array", items: { type: elementType } };
+            parentSchema.properties[propertyName] = { type: "array", items: [{ type: elementType }] };
           }
         } else {
           parentSchema.properties[propertyName] = { type: getType(member.type) };


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This PR contains two bug fixes

- [Fix mapFunction getting bundled inside an IIFE for datamapper](https://github.com/wso2/maven-tools/commit/c1c51ca6b9d51c8fcc84e9159389aadbe7120b63)
- [Fix array elements not getting added inside an array in the json schema for Datamapper](https://github.com/wso2/maven-tools/commit/940c658f5adf210726cad06fd75262aaa1c012ef) 

