### PR TITLE
Fix vscode car plugin

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -97,13 +97,14 @@ public class CARMojo extends AbstractMojo {
 
             processCARCreation(basedir, artifactFolderPath, resourcesFolderPath);
         } finally {
-            if (bundler != null) {
-                try {
-                    bundler.deleteGeneratedDatamapperArtifacts();
-                } catch (DataMapperException e) {
-                    getLog().error("Error during data mapper cleanup: " + e.getMessage(), e);
-                }
-            }
+            // TODO: Plugin should not delete the files in the project. Need to fix this.
+//            if (bundler != null) {
+//                try {
+//                    bundler.deleteGeneratedDatamapperArtifacts();
+//                } catch (DataMapperException e) {
+//                    getLog().error("Error during data mapper cleanup: " + e.getMessage(), e);
+//                }
+//            }
         }
     }
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -184,7 +184,7 @@ class CAppHandler extends AbstractXMLDoc {
             return;
         }
         for (File connector : connectorFiles) {
-            if (connector.isFile()) {
+            if (connector.isFile() && connector.getName().endsWith(".zip")) {
                 String fileName = connector.getName();
                 int lastIndex = fileName.lastIndexOf('-');
                 String name = fileName.substring(0, lastIndex);
@@ -505,6 +505,8 @@ class CAppHandler extends AbstractXMLDoc {
                             Constants.TEMP_TARGET_DIR_NAME, project.getArtifactId(), Constants.CLASS_MEDIATOR_TYPE,
                     Constants.SERVER_ROLE_EI, project.getVersion(), jarName, project.getArtifactId() + "_" +
                             project.getVersion());
+            // delete the jar file after copying to the CAPP
+            jarFile.delete();
         }
     }
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
@@ -743,10 +743,11 @@ public class DataMapperBundler {
         String[] pathsToDelete = {
             "." + File.separator + Constants.TARGET_DIR_NAME
         };
+        String excludeRegex = ".*\\.jar";
 
         for (String path : pathsToDelete) {
             File file = new File(path);
-            deleteRecursively(file);
+            deleteRecursively(file, excludeRegex);
         }
     }
 
@@ -754,18 +755,22 @@ public class DataMapperBundler {
      * Recursively deletes files and directories.
      *
      * @param file The file or directory to delete.
+     * @param excludeRegex The regex pattern to exclude files from deletion.
      */
-    private void deleteRecursively(File file) {
+    private void deleteRecursively(File file, String excludeRegex) {
+
         if (file.isDirectory()) {
             File[] entries = file.listFiles();
             if (entries != null) {
                 for (File entry : entries) {
-                    deleteRecursively(entry);
+                    deleteRecursively(entry, excludeRegex);
                 }
             }
         }
-        if (!file.delete()) {
-            mojoInstance.logError("Failed to delete " + file.getPath());
+        if (excludeRegex == null || !file.getAbsolutePath().matches(excludeRegex)) {
+            if (!file.delete()) {
+                mojoInstance.logError("Failed to delete " + file.getPath());
+            }
         }
     }
 }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
@@ -549,7 +549,7 @@ public class DataMapperBundler {
         List<Path> subDirectories = new ArrayList<>();
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(dirPath)) {
             for (Path path : stream) {
-                if (Files.isDirectory(path) && !path.equals(dirPath)) {
+                if (Files.isDirectory(path) && !path.equals(dirPath) && isDataMapperDirectory(path)) {
                     subDirectories.add(path);
                 }
             }
@@ -559,6 +559,12 @@ public class DataMapperBundler {
             throw new DataMapperException("Failed to find data mapper directories.", e);
         }
         return subDirectories;
+    }
+
+    private boolean isDataMapperDirectory(Path path) {
+
+        String dirName = path.getFileName().toString();
+        return Files.exists(Paths.get(path.toString(), dirName + ".ts"));
     }
 
     /**


### PR DESCRIPTION
1. The datamapper bundler is considering all the sub folder inside the gov/datamapper as datampper config. This PR fixes it by adding validation to the subfolders inside gov/datamapper to ensure that it is a datamapper config folder.
2.  Fixes the class mediator not getting packed in the car file when there is datamapper available in the project.
3. Fixes the build failure when there is other files than zip in the connector folder.