### PR TITLE
Improve unit test plugin to handle datamapper resources

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
@@ -88,8 +88,8 @@ public class DataMapperBundler {
         configureNpm();
         bundleDataMappers(dataMappers);
         generateDataMapperSchemas(dataMappers);
-
         removeBundlingArtifacts();
+        copyDataMapperFilesToTarget();
     }
 
     /**
@@ -211,6 +211,23 @@ public class DataMapperBundler {
         createConfigJsonForSchemaGeneration();
         for (Path dataMapper : dataMappers) {
             generateDataMapperSchema(dataMapper);
+        }
+    }
+
+    /**
+     * Copies the data mapper files to the target directory.
+     * This might be utilized for the unit tests
+     *
+     * @throws DataMapperException if an error occurs while removing the bundling artifacts.
+     */
+    private void copyDataMapperFilesToTarget() throws DataMapperException {
+        Path dataMapperPath = Paths.get(resourcesDirectory + File.separator + Constants.DATA_MAPPER_DIR_PATH);
+        try {
+            FileUtils.copyDirectory(dataMapperPath.toFile(),
+                    Paths.get("." + File.separator + Constants.TARGET_DIR_NAME + File.separator +
+                            Constants.DATA_MAPPER_DIR_NAME).toFile());
+        } catch (IOException e) {
+            throw new DataMapperException("Failed to copy data mapper files to target directory.", e);
         }
     }
 
@@ -672,6 +689,21 @@ public class DataMapperBundler {
      */
     private void ensureDataMapperTargetExists() throws DataMapperException {
         Path dataMapperPath = Paths.get("." + File.separator + Constants.TARGET_DIR_NAME);
+        if (!Files.exists(dataMapperPath)) {
+            try {
+                Files.createDirectories(dataMapperPath);
+            } catch (IOException e) {
+                throw new DataMapperException("Failed to create data-mapper artifacts directory: " + dataMapperPath, e);
+            }
+        }
+    }
+
+    /**
+     * Ensures that the data mapper directory exists.
+     * @throws DataMapperException if an error occurs while creating the datamapper artifacts directory.
+     */
+    private void ensureDataMapperFolderExists() throws DataMapperException {
+        Path dataMapperPath = Paths.get("." + File.separator + Constants.DATA_MAPPER_DIR_NAME);
         if (!Files.exists(dataMapperPath)) {
             try {
                 Files.createDirectories(dataMapperPath);

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
@@ -699,21 +699,6 @@ public class DataMapperBundler {
     }
 
     /**
-     * Ensures that the data mapper directory exists.
-     * @throws DataMapperException if an error occurs while creating the datamapper artifacts directory.
-     */
-    private void ensureDataMapperFolderExists() throws DataMapperException {
-        Path dataMapperPath = Paths.get("." + File.separator + Constants.DATA_MAPPER_DIR_NAME);
-        if (!Files.exists(dataMapperPath)) {
-            try {
-                Files.createDirectories(dataMapperPath);
-            } catch (IOException e) {
-                throw new DataMapperException("Failed to create data-mapper artifacts directory: " + dataMapperPath, e);
-            }
-        }
-    }
-
-    /**
      * Removes source files from the target directory.
      * @throws DataMapperException if an error occurs while removing the source files.
      */

--- a/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/Constants.java
+++ b/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/Constants.java
@@ -87,4 +87,9 @@ class Constants {
     static final String WSO2_MI = "wso2mi";
     static final String WSO2_MI_WITH_DASH = "wso2mi-";
     static final String ZIP = ".zip";
+    static final String TS = ".ts";
+    static final String DMC = ".dmc";
+    static final String INPUT_SCHEMA = "_inputSchema.json";
+    static final String OUTPUT_SCHEMA = "_outputSchema.json";
+    static final String DATA_MAPPER = "datamapper";
 }


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/mi-vscode/issues/409

Datamapper resources are created during project build time and they are removed after build phase. Hence they are not available for unit test plugins during the test phase. This improvement persists the generated resources in the target directory so that they can be accessed by unit test plugin during test phase.

When a user provides a `.ts` file as a registry resource for a unit test, the related `.dmc`, `_inputSchema.json` and  `_outputSchema.json` entries will be derived and added to the unittest.xml that is sent to the server. The resources will be referred from the target directory. 

Example unit test suite:

```
<unit-test>
    <artifacts>
        <test-artifact>
            <artifact>src/main/wso2mi/artifacts/apis/SalesforceLeads.xml</artifact>
        </test-artifact>
        <supportive-artifacts/>
        <registry-resources>
      <registry-resource>
        <file-name>SalesforceLeadsMappingConfig.ts</file-name>
        <artifact>src/main/wso2mi/resources/registry/gov/datamapper/SalesforceLeadsMappingConfig/SalesforceLeadsMappingConfig.ts</artifact>
        <registry-path>/_system/governance/datamapper/SalesforceLeadsMappingConfig</registry-path>
        <media-type>text/plain</media-type>
      </registry-resource>
    </registry-resources>
        <connector-resources/>
    </artifacts>
    <test-cases>
        <test-case name="JsonToXmlMapping">
            <input>
                <request-path>/convertToLead</request-path>
                <request-method>POST</request-method>
                <payload><![CDATA[{"owner":[{"ID":"005D0000000nVYVIA3","name":"Paul","city":"CA","code":"94041", "country":"US"},{"ID":"005D0000000nVYVIA2","name":"Smith","city":"CA","code":"94041","country":"US"}],"lead":[{"ID":"00QD000000FP14JMAU","name":"Carl","city":"NC","code":"97788","country":"US"},{"ID":"00QD000000FP14JMAT","name":"Carl","city":"NC","code":"97788","country":"US"}],"sendNotificationEmail":"true","convertedStatus":"Qualified","doNotCreateOpportunity":"true","opportunityName":"Partner Opportunity","overwriteLeadSource":"true","sessionId":"QwWsHJyTPW.1pd0_jXlNKOSU"}]]></payload>
                <properties>
                    <property name="Content-Type" scope="transport" value="application/json"/>
                </properties>
            </input>
            <assertions>
                <assertEquals>
                    <actual>$body</actual>
                    <expected><![CDATA[<soapenv:Envelope xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope/" xmlns:urn="urn:enterprise.soap.sforce.com">
    <soapenv:Header>
        <urn:SessionHeader>
            <urn:sessionId>QwWsHJyTPW.1pd0_jXlNKOSU</urn:sessionId>
        </urn:SessionHeader>
    </soapenv:Header>
    <soapenv:Body>
        <urn:convertLead>
            <urn:leadConverts>
                <urn:convertedStatus/>
                <urn:doNotCreateOpportunity>true</urn:doNotCreateOpportunity>
                <urn:leadId>00QD000000FP14JMAU</urn:leadId>
                <urn:opportunityName>Carl</urn:opportunityName>
                <urn:ownerId/>
                <urn:sendNotificationEmail>true</urn:sendNotificationEmail>
            </urn:leadConverts>
            <urn:leadConverts>
                <urn:convertedStatus/>
                <urn:doNotCreateOpportunity>true</urn:doNotCreateOpportunity>
                <urn:leadId>00QD000000FP14JMAT</urn:leadId>
                <urn:opportunityName>Carl</urn:opportunityName>
                <urn:ownerId/>
                <urn:sendNotificationEmail>true</urn:sendNotificationEmail>
            </urn:leadConverts>
        </urn:convertLead>
    </soapenv:Body>
</soapenv:Envelope>]]></expected>
                    <message>JSON to XML mapping test case failed.</message>
                </assertEquals>
            </assertions>
        </test-case>
    </test-cases>
    <mock-services/>
</unit-test>

```