### PR TITLE
Add the capability to execute a single test case

### DIFF
--- a/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/SynapseTestCaseFileReader.java
+++ b/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/SynapseTestCaseFileReader.java
@@ -73,12 +73,12 @@ class SynapseTestCaseFileReader {
             QName qualifiedTestCases = new QName("", Constants.TEST_CASES_TAG, "");
             OMElement testCasesNode = importedXMLFile.getFirstChildWithName(qualifiedTestCases);
             if (testCasesNode != null) {
-                int numberOfTestCases = 0;
                 Iterator<OMElement> testCaseIterator = testCasesNode.getChildElements();
                 if (!testCaseIterator.hasNext()) {
                     return Constants.NO_TEST_CASES;
                 } else {
                     if (StringUtils.isNotBlank(synapseTestCaseName)) {
+                        int numberOfTestCases = 0;
                         List<OMElement> testCasesToRemove = new ArrayList<>();
                         while (testCaseIterator.hasNext()) {
                             numberOfTestCases++;

--- a/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/UnitTestCasesMojo.java
+++ b/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/UnitTestCasesMojo.java
@@ -64,6 +64,9 @@ public class UnitTestCasesMojo extends AbstractMojo {
     @Parameter(property = "testCasesFilePath")
     private String testCasesFilePath;
 
+    @Parameter(property = "testCaseName")
+    private String synapseTestCaseName;
+
     @Parameter(property = "server")
     private SynapseServer server;
 
@@ -158,7 +161,7 @@ public class UnitTestCasesMojo extends AbstractMojo {
         for (String synapseTestCaseFile : synapseTestCasePaths) {
 
             String responseFromUnitTestFramework = UnitTestClient.executeTests
-                    (synapseTestCaseFile, serverHost, serverPort);
+                    (synapseTestCaseFile, serverHost, serverPort, synapseTestCaseName);
 
             if (responseFromUnitTestFramework != null
                     && !responseFromUnitTestFramework.equals(Constants.NO_TEST_CASES)) {

--- a/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/UnitTestClient.java
+++ b/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/UnitTestClient.java
@@ -42,16 +42,17 @@ class UnitTestClient {
      * @param synapseTestCaseFilePath synapse test case file path
      * @param synapseHost synapse unit test server host
      * @param synapsePort synapse unit test server port
+     * @param synapseTestCaseName synapse test case name
      * @return response from the unit testing agent received via TCP transport
      * @throws IOException when tcp socket not initialized
      */
-    static String executeTests(String synapseTestCaseFilePath, String synapseHost, String synapsePort)
+    static String executeTests(String synapseTestCaseFilePath, String synapseHost, String synapsePort, String synapseTestCaseName)
             throws IOException {
         String responseFromServer = null;
         String deployableMessage = null;
         try {
             //check whether unit test suite has test cases or not
-            deployableMessage = SynapseTestCaseFileReader.processArtifactData(synapseTestCaseFilePath);
+            deployableMessage = SynapseTestCaseFileReader.processArtifactData(synapseTestCaseFilePath, synapseTestCaseName);
             if (deployableMessage != null && deployableMessage.equals(Constants.NO_TEST_CASES)) {
                 return deployableMessage;
             }


### PR DESCRIPTION
This PR will add the capability to execute a single test case within the unit tests by passing the required test case name as a parameter in the mvn test command. Therefore this will fix the issue https://github.com/wso2/mi-vscode/issues/463