### PR TITLE
Fix project build failure when test folder is not available

### DIFF
--- a/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/UnitTestCasesMojo.java
+++ b/wso2-synapse-unit-test-plugin/src/main/java/org/wso2/synapse/unittest/UnitTestCasesMojo.java
@@ -145,6 +145,11 @@ public class UnitTestCasesMojo extends AbstractMojo {
     private void testCaseRunner() throws IOException {
         List<String> synapseTestCasePaths = getTestCasesFileNamesWithPaths(testCasesFilePath);
 
+        if (synapseTestCasePaths.isEmpty()) {
+            getLog().info("Project does not include any unit tests.");
+            return;
+        }
+
         getLog().info("Detect " + synapseTestCasePaths.size() + " Synapse test case files to execute");
         getLog().info("");
 
@@ -195,6 +200,10 @@ public class UnitTestCasesMojo extends AbstractMojo {
      */
     private ArrayList<String> getTestCasesFileNamesWithPaths(String testFileFolder) {
         ArrayList<String> fileNamesWithPaths = new ArrayList<>();
+
+        if (!(new File(testFileFolder).exists())) {
+            return fileNamesWithPaths;
+        }
 
         if (testFileFolder.endsWith(Constants.XML_EXTENSION)) {
             fileNamesWithPaths.add(testFileFolder);


### PR DESCRIPTION
This PR will resolve the build issue that occurs when the test folder is not present in the project folder structure. Therefore this will fix the issue https://github.com/wso2/mi-vscode/issues/521