### PR TITLE
Check existing metadata files for APIs before creation

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -31,6 +31,7 @@ import org.apache.axiom.om.OMAttribute;
 import org.apache.axiom.om.OMDocument;
 import org.apache.axiom.om.OMElement;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.wso2.maven.model.Artifact;
@@ -121,7 +122,12 @@ class CAppHandler extends AbstractXMLDoc {
                         if (Constants.API_TYPE.equals(type)) {
                             // api version can be null
                             apiList.put(name, configVersion);
-                            String metadataFilename = name + "_metadata.yaml";
+                            String metadataFilename;
+                            if (StringUtils.isBlank(configVersion)) {
+                                metadataFilename = name + "_metadata.yaml";
+                            } else {
+                                metadataFilename = name + "_" + configVersion + "_metadata.yaml";
+                            }
                             File resourcesFolder = artifactsDir.toPath().getParent().getParent()
                                     .resolve(Constants.RESOURCES).toFile();
                             File metadataFolder = new File(resourcesFolder, Constants.METADATA_DIR_NAME);

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -121,8 +121,15 @@ class CAppHandler extends AbstractXMLDoc {
                         if (Constants.API_TYPE.equals(type)) {
                             // api version can be null
                             apiList.put(name, configVersion);
-                            writeMetadataFile(name, configElement, archiveDirectory, false, version);
-                            addMetadataDependencies(metadataDependencies, configElement, false, version);
+                            String metadataFilename = name + "_metadata.yaml";
+                            File resourcesFolder = artifactsDir.toPath().getParent().getParent()
+                                    .resolve(Constants.RESOURCES).toFile();
+                            File metadataFolder = new File(resourcesFolder, Constants.METADATA_DIR_NAME);
+                            File metaFile = new File(metadataFolder, metadataFilename);
+                            if (!metaFile.exists()) {
+                                writeMetadataFile(name, configElement, archiveDirectory, false, version);
+                                addMetadataDependencies(metadataDependencies, configElement, false, version);
+                            }
                         }
                         if (configVersion == null) {
                             apiHasVersion = false;


### PR DESCRIPTION
This PR will fix the issue of metadata files being duplicated for APIs in scenarios where a metadata file already exists in project resources for an API.

Fix issue: https://github.com/wso2/mi-vscode/issues/564