### PR TITLE
Move class mediators to separate folder inside CAPP

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -772,12 +772,12 @@ class CAppHandler extends AbstractXMLDoc {
         String jarName = project.getArtifactId() + "-" + project.getVersion() + ".jar";
         File jarFile = new File(Paths.get(project.getBasedir().toString(), "target", jarName).toString());
         if (jarFile.exists()) {
-            dependencies.add(new ArtifactDependency(project.getArtifactId(), project.getVersion(),
-                    Constants.SERVER_ROLE_EI, true));
+            dependencies.add(new ArtifactDependency(project.getArtifactId() + Constants.CLASS_MEDIATORS
+                    , project.getVersion(), Constants.SERVER_ROLE_EI, true));
             writeArtifactAndFile(jarFile, project.getBasedir().toString() + File.separator +
-                            Constants.TEMP_TARGET_DIR_NAME, project.getArtifactId(), Constants.CLASS_MEDIATOR_TYPE,
-                    Constants.SERVER_ROLE_EI, project.getVersion(), jarName, project.getArtifactId() + "_" +
-                            project.getVersion());
+                            Constants.TEMP_TARGET_DIR_NAME, project.getArtifactId() + Constants.CLASS_MEDIATORS,
+                    Constants.CLASS_MEDIATOR_TYPE, Constants.SERVER_ROLE_EI, project.getVersion(), jarName,
+                    project.getArtifactId() + Constants.CLASS_MEDIATORS + "_" + project.getVersion());
             // delete the jar file after copying to the CAPP
             jarFile.delete();
         }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -102,6 +102,7 @@ public class Constants {
     public static final String GROUP_ID = "groupId";
     public static final String VERSION = "version";
     public static final String ZIP_EXTENSION = ".zip";
+    public static final String CLASS_MEDIATORS = "_class_mediators";
 
     private Constants() {
     }


### PR DESCRIPTION
## Purpose
> Move class mediators to a separate folder inside CAPP, so that another artifact can exist which has the same name as artifact name. 
Fixes wso2/mi-vscode/issues/629