### PR TITLE
Add improved dependency resolving functionality to handle connectors …

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -110,7 +110,6 @@ public class Constants {
     public static final String CONNECTOR = "connector";
 
     public static final String CONNECTION_TYPE = "connectionType";
-    public static final String CONNECTOR_XML = "connector.xml";
     public static final String LOCAL_ENTRIES_FOLDER_PATH = ARTIFACTS_FOLDER_PATH + File.separator + LOCAL_ENTRIES_DIR_NAME;
 
     private Constants() {

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -67,7 +67,7 @@ public class Constants {
     static final String GOV_REG_PREFIX = "/_system/governance";
     static final String CONF_REG_PREFIX = "/_system/config";
     static final String GOV_MI_RESOURCES_PREFIX = "/_system/governance/mi-resources";
-    static final String GOV_FOLDER= "gov";
+    static final String GOV_FOLDER = "gov";
     static final String CONF_FOLDER = "conf";
     static final String REG_INFO_FILE = "registry-info.xml";
     static final String TYPE = "type";
@@ -103,6 +103,10 @@ public class Constants {
     public static final String VERSION = "version";
     public static final String ZIP_EXTENSION = ".zip";
     public static final String CLASS_MEDIATORS = "_class_mediators";
+
+    public static final String CONNECTION_TYPE = "connectionType";
+    public static final String CONNECTOR_XML = "connector.xml";
+    public static final String LOCAL_ENTRIES_FOLDER_PATH = ARTIFACTS_FOLDER_PATH + File.separator + LOCAL_ENTRIES_DIR_NAME;
 
     private Constants() {
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -197,7 +197,7 @@ public class ConnectorDependencyResolver {
 
         // Extract dependencies
         List<Map<String, String>> dependencies = (List<Map<String, String>>) yamlData.get(Constants.DEPENDENCIES);
-        List<String> dependenciesList = new ArrayList<>();
+        Set<String> dependencySet = new HashSet<>();
         if (dependencies != null) {
             for (Map<String, String> dependency : dependencies) {
                 String groupId = dependency.get(Constants.GROUP_ID);
@@ -216,9 +216,11 @@ public class ConnectorDependencyResolver {
                     }
                 }
 
-                dependenciesList.add(groupId + ":" + artifactId + ":" + version);
+                dependencySet.add(groupId + ":" + artifactId + ":" + version);
             }
         }
+
+        List<String> dependenciesList = new ArrayList<>(dependencySet);
         resolveAndCopyDependencies(dependenciesList, repositoriesList, libDir, invoker, carMojo);
     }
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -216,7 +216,7 @@ public class ConnectorDependencyResolver {
                     }
 
                     // skip the dependency if connectionType is not used
-                    if (!connectionTypeMap.containsKey(connectionType)) {
+                    if (connectionTypeMap == null || !connectionTypeMap.containsKey(connectionType)) {
                         carMojo.logInfo("Skipping dependency: " + groupId + ":" + artifactId + ":" + version
                                 + " as the connectionType: " + connectionType + " is not found in the local entries.");
                         continue;


### PR DESCRIPTION
…with dynamic dependencies

## Purpose
> Added functionality to handle resolving dependencies of connectors that have dynamic dependencies, 
(eg: DB connector may have mysql or postresql dependency based on the use case)

utilizes new parameter connectionType in descriptor.yml file
example:
- groupId: "com.mysql"
    artifactId: "mysql-connector-j"
    version: "9.2.0"
    connectionType: "MySQL"
 - groupId: "com.oracle.database.jdbc"
    artifactId: "ojdbc8"
    version: "21.9.0.0"
    connectionType: "Oracle"