### PR TITLE
Improve datamapper schemaGenerator to handle fields with underscore in xml payloads

### DIFF
--- a/vscode-car-plugin/src/main/resources/schemaGenerator.ts
+++ b/vscode-car-plugin/src/main/resources/schemaGenerator.ts
@@ -190,10 +190,12 @@ function generateJsonSchemaFromAST(ast: ts.SourceFile): any {
     }
     // Replace underscores with colons for XML namespaces
     if (formattedName.includes("_")) {
-      if ((schema.inputType && schema.inputType.toLowerCase() === "xml" && schema.namespaces) ||
-        (schema.outputType && schema.outputType.toLowerCase() === "xml" && schema.namespaces)) {
-          formattedName = formattedName.replace("_", ":");
-      }
+        const prefix = formattedName.split("_")[0];
+        const namespaceExists = schema.namespaces && schema.namespaces.some(ns => ns.prefix === prefix);
+        if ((schema.inputType && schema.inputType.toLowerCase() === "xml" && namespaceExists) ||
+            (schema.outputType && schema.outputType.toLowerCase() === "xml" && namespaceExists)) {
+            formattedName = formattedName.replace("_", ":");
+        }
     }
     return formattedName;
   }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Resolves https://github.com/wso2/mi-vscode/issues/764

When schema generator tries to generate schema for XML payloads, it replaces the "\_" with ":" considering them as namespaces. But XML payload fields can have "\_" without being a namespace. Hence an additional check has been added to check whether the prefix before "\_" is within the namespace fields.