### PR TITLE
Implement new artifact type for connector dependencies

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -20,6 +20,7 @@ package org.wso2.maven;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.*;
@@ -422,12 +423,37 @@ class CAppHandler extends AbstractXMLDoc {
      */
     private void writeArtifactAndFile(File configFile, String archiveDirectory, String name, String type,
                                       String serverRole, String configVersion, String fileName, String folderName) {
+
+        writeArtifactAndFile(configFile, archiveDirectory, name, type, serverRole, configVersion, fileName,
+                folderName, null);
+    }
+
+    /**
+     * Method to write artifact.xml and file to the archive directory.
+     *
+     * @param configFile       configuration file to write to the archive
+     * @param archiveDirectory path to archive directory
+     * @param name             name of the artifact
+     * @param type             type of the artifact
+     * @param serverRole       server role of the artifact
+     * @param configVersion    version of the artifact
+     * @param fileName         name of the file
+     * @param folderName       name of the folder
+     * @param connectorName    name of the connector
+     */
+    private void writeArtifactAndFile(File configFile, String archiveDirectory, String name, String type,
+                                      String serverRole, String configVersion, String fileName, String folderName,
+                                      String connectorName) {
+
         Artifact artifactObject = new Artifact();
         artifactObject.setName(name);
         artifactObject.setType(type);
         artifactObject.setVersion(configVersion);
         artifactObject.setServerRole(serverRole);
         artifactObject.setFile(fileName);
+        if (connectorName != null) {
+            artifactObject.setConnector(connectorName);
+        }
         try {
             String artifactDataAsString = createArtifactData(artifactObject);
             org.wso2.developerstudio.eclipse.utils.file.FileUtils.createFile(
@@ -699,6 +725,9 @@ class CAppHandler extends AbstractXMLDoc {
         artifactElement = addAttribute(artifactElement, Constants.VERSION, artifact.getVersion());
         artifactElement = addAttribute(artifactElement, Constants.TYPE, artifact.getType());
         artifactElement = addAttribute(artifactElement, Constants.SERVER_ROLE, artifact.getServerRole());
+        if (artifact.getConnector() != null) {
+            artifactElement = addAttribute(artifactElement, Constants.CONNECTOR, artifact.getConnector());
+        }
         OMElement fileChildElement = getElement(Constants.FILE, artifact.getFile());
         artifactElement.addChild(fileChildElement);
 
@@ -827,22 +856,46 @@ class CAppHandler extends AbstractXMLDoc {
             }
         }
 
-        // process lib dependencies of connectors
-        File libFolder = new File(Paths.get(project.getBasedir().toString(), Constants.DEFAULT_TARGET_FOLDER,
-                Constants.LIBS).toString());
-        if (libFolder.exists()) {
-            File[] libFiles = libFolder.listFiles();
-            if (libFiles != null) {
-                for (File libFile : libFiles) {
-                    if (libFile.isFile() && libFile.getName().endsWith(".jar")) {
-                        dependencies.add(new ArtifactDependency(libFile.getName().substring(0, libFile.getName().length() - 4),
-                                project.getVersion(), Constants.SERVER_ROLE_EI, true));
-                        writeArtifactAndFile(libFile, project.getBasedir().toString() + File.separator +
-                                Constants.TEMP_TARGET_DIR_NAME, libFile.getName().substring(0, libFile.getName().length() - 4),
-                                Constants.CLASS_MEDIATOR_TYPE, Constants.SERVER_ROLE_EI, project.getVersion(), libFile.getName(),
-                                libFile.getName().substring(0, libFile.getName().length() - 4));
-                    }
+        // Process library dependencies of connectors
+        File libFolder = new File(project.getBasedir(), Constants.DEFAULT_TARGET_FOLDER + File.separator + Constants.LIBS);
+
+        if (!libFolder.exists()) {
+            return; // Exit if the lib folder does not exist
+        }
+
+        File[] connectorDeps = libFolder.listFiles();
+        if (connectorDeps == null) {
+            return; // Exit if no files/folders exist inside lib folder
+        }
+
+        for (File connectorDir : connectorDeps) {
+            if (!connectorDir.isDirectory()) {
+                continue; // Skip if not a directory
+            }
+
+            String connectorName = connectorDir.getName();
+            File[] libFiles = connectorDir.listFiles(new FilenameFilter() {
+                @Override
+                public boolean accept(File dir, String name) {
+                    return name.endsWith(".jar");
                 }
+            }); // Filter only JAR files
+
+            if (libFiles == null) {
+                continue;
+            }
+
+            for (File libFile : libFiles) {
+                String fileNameWithoutExt = libFile.getName().substring(0, libFile.getName().length() - 4);
+
+                // Add dependency to the list
+                dependencies.add(new ArtifactDependency(
+                        fileNameWithoutExt, project.getVersion(), Constants.SERVER_ROLE_EI, true));
+
+                // Write artifact and file details
+                writeArtifactAndFile(libFile, project.getBasedir() + File.separator + Constants.TEMP_TARGET_DIR_NAME,
+                        fileNameWithoutExt, Constants.CONNECTOR_DEPENDENCY_TYPE, Constants.SERVER_ROLE_EI,
+                        project.getVersion(), libFile.getName(), fileNameWithoutExt, connectorName);
             }
         }
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -895,7 +895,8 @@ class CAppHandler extends AbstractXMLDoc {
                 // Write artifact and file details
                 writeArtifactAndFile(libFile, project.getBasedir() + File.separator + Constants.TEMP_TARGET_DIR_NAME,
                         fileNameWithoutExt, Constants.CONNECTOR_DEPENDENCY_TYPE, Constants.SERVER_ROLE_EI,
-                        project.getVersion(), libFile.getName(), fileNameWithoutExt, connectorName);
+                        project.getVersion(), libFile.getName(), connectorName + "_" +
+                        fileNameWithoutExt, connectorName);
             }
         }
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -58,6 +58,7 @@ public class Constants {
     static final String METADATA_TYPE = "synapse/metadata";
     static final String CAPP_TYPE = "carbon/application";
     static final String CLASS_MEDIATOR_TYPE = "lib/synapse/mediator";
+    static final String CONNECTOR_DEPENDENCY_TYPE = "lib/connector/dependency";
     static final String ARTIFACTS_FOLDER_PATH = "src" + File.separator + "main" + File.separator
             + "wso2mi" + File.separator + "artifacts";
     static final String RESOURCES_FOLDER_PATH = "src" + File.separator + "main" + File.separator
@@ -72,7 +73,6 @@ public class Constants {
     static final String REG_INFO_FILE = "registry-info.xml";
     static final String TYPE = "type";
     static final String SERVER_ROLE = "serverRole";
-    static final String NAME = "name";
     static final String DESCRIPTION = "description";
     static final String FILE = "file";
     static final String ITEM = "item";
@@ -103,6 +103,11 @@ public class Constants {
     public static final String VERSION = "version";
     public static final String ZIP_EXTENSION = ".zip";
     public static final String CLASS_MEDIATORS = "_class_mediators";
+    public static final String CONNECTOR_XML = "connector.xml";
+    public static final String COMPONENT = "component";
+    public static final String NAME = "name";
+    public static final String PACKAGE = "package";
+    public static final String CONNECTOR = "connector";
 
     private Constants() {
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -210,7 +210,7 @@ public class ConnectorDependencyResolver {
         resolveAndCopyDependencies(dependenciesList, repositoriesList, libDir, invoker, carMojo, connectorName);
     }
 
-    public static void resolveAndCopyDependencies(List<String> dependencies, List<String> repositories,
+    private static void resolveAndCopyDependencies(List<String> dependencies, List<String> repositories,
                                                   String libDir, Invoker invoker, CARMojo carMojo, String connectorName)
             throws LibraryResolverException {
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/model/Artifact.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/model/Artifact.java
@@ -28,6 +28,7 @@ public class Artifact {
     private String serverRole;
     private String type;
     private String file;
+    private String connector;
 
     /**
      * @return the name
@@ -97,5 +98,21 @@ public class Artifact {
      */
     public void setFile(String file) {
         this.file = file;
+    }
+
+    /**
+     * @return the connector
+     */
+    public String getConnector() {
+
+        return connector;
+    }
+
+    /**
+     * @param connector of the artifact
+     */
+    public void setConnector(String connector) {
+
+        this.connector = connector;
     }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

With this approach, connector dependencies are added with new artifact type to car file with the relevant connector qualified name

Example artifact.xml

```
<?xml version="1.0" encoding="UTF-8"?><artifact name="kafka_2.13-3.7.0" version="1.0.0" type="lib/connector/dependency" serverRole="EnterpriseIntegrator" connector="{org.wso2.carbon.connector}kafkaTransport">
    <file>kafka_2.13-3.7.0.jar</file>
</artifact>

```