### PR TITLE
Add prepend node config flag to datamapper bundling

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/Constants.java
@@ -55,6 +55,8 @@ class Constants {
         + EXEC_MVN_PLUGIN_ARTIFACT_ID + ":" + EXEC_MVN_PLUGIN_VERSION + ":" + EXEC_COMMAND;
     static final String NPM_RUN_BUILD_GOAL = EXEC_GOAL + "@" + BUILD_COMMAND;
     public static final String PREPEND_NODE_CONFIG = "config set scripts-prepend-node-path auto";
+    public static final String PREPEND_NODE_CONFIG_FLAG = "--scripts-prepend-node-path=auto";
+
 
     private Constants() {
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
@@ -249,7 +249,7 @@ public class DataMapperBundler {
         request.setBaseDirectory(npmDirectory.toFile());
         request.setGoals(Collections.singletonList(Constants.NPM_RUN_BUILD_GOAL
                 + " -Dexec.executable=\"" + getNpmExecutablePath() + "\""
-                + " -Dexec.args=\"" + Constants.RUN_BUILD + "\""));
+                + " -Dexec.args=\"" + Constants.RUN_BUILD + " " + Constants.PREPEND_NODE_CONFIG_FLAG + "\""));
 
         executeRequest(request, "Failed to bundle data mapper: " + dataMapperName);
 
@@ -279,7 +279,7 @@ public class DataMapperBundler {
         request.setGoals(Collections.singletonList(Constants.NPM_RUN_BUILD_GOAL
                 + " -Dexec.executable=\"" + getNpmExecutablePath() + "\""
                 + " -Dexec.args=\"" + Constants.RUN_GENERATE + " " + dataMapper + File.separator
-                + dataMapperName + ".ts" + "\""));
+                + dataMapperName + ".ts" + " " + Constants.PREPEND_NODE_CONFIG_FLAG + "\""));
 
         executeRequest(request, "Failed to bundle data mapper: " + dataMapperName);
     }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Adding this flag makes sure that npm sets the node path to the system PATH if it is not available.

Fixes https://github.com/wso2/mi-vscode/issues/636