### PR TITLE
Give prominence to the api-definition folder over the metadata folder

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -352,6 +352,9 @@ class CAppHandler extends AbstractXMLDoc {
                     apiVersion = version;
                     apiVersionExists = false;
                 }
+                if (isApiDefinitionPresent(apiName, apiVersion, apiVersionExists, metadataDependencies)) {
+                    continue;
+                }
                 File swaggerFile = new File(metadataFolder, swaggerFilename);
                 File metaFile = new File(metadataFolder, metadataFilename);
                 if (swaggerFile.exists() && metaFile.exists()) {
@@ -921,6 +924,17 @@ class CAppHandler extends AbstractXMLDoc {
             throw new MojoExecutionException("Error serializing", e);
         }
         return outputStream.toString();
+    }
+
+    private boolean isApiDefinitionPresent(String apiName, String apiVersion, boolean apiVersionExists,
+                                           List<ArtifactDependency> metadataDependencies) {
+        apiName = apiVersionExists ? (apiName + "_" + apiVersion + "_swagger") : (apiName + "_swagger");
+        for (ArtifactDependency dependency : metadataDependencies) {
+            if (dependency.getArtifact().equals(apiName) && dependency.getVersion().equals(apiVersion)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This PR will make the required changes to obtain the swagger file of an API in the metadata folder only in a scenario where it is not available in the api-definition folder.