### PR TITLE
Improve vscode car plugin to resolve dependencies of imported connectors

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -38,7 +38,6 @@ public class Constants {
     static final String CONF_DIR_NAME = "conf";
     static final String DATASERVICES_DIR_NAME = "data-services";
     static final String METADATA_DIR_NAME = "metadata";
-    static final String CONNECTORS_DIR_NAME = "connectors";
     static final String REGISTRY_DIR_NAME = "registry";
     static final String API_TYPE = "synapse/api";
     static final String ENDPOINT_TYPE = "synapse/endpoint";
@@ -61,8 +60,6 @@ public class Constants {
     static final String CONNECTOR_DEPENDENCY_TYPE = "lib/connector/dependency";
     static final String ARTIFACTS_FOLDER_PATH = "src" + File.separator + "main" + File.separator
             + "wso2mi" + File.separator + "artifacts";
-    static final String RESOURCES_FOLDER_PATH = "src" + File.separator + "main" + File.separator
-            + "wso2mi" + File.separator + "resources";
     static final String SERVER_ROLE_EI = "EnterpriseIntegrator";
     static final String SERVER_ROLE_DSS = "EnterpriseServiceBus";
     static final String GOV_REG_PREFIX = "/_system/governance";
@@ -108,9 +105,11 @@ public class Constants {
     public static final String NAME = "name";
     public static final String PACKAGE = "package";
     public static final String CONNECTOR = "connector";
-
+    public static final String CONNECTORS_DIR_NAME = "connectors";
     public static final String CONNECTION_TYPE = "connectionType";
     public static final String LOCAL_ENTRIES_FOLDER_PATH = ARTIFACTS_FOLDER_PATH + File.separator + LOCAL_ENTRIES_DIR_NAME;
+    public static final String RESOURCES_FOLDER_PATH = "src" + File.separator + "main" + File.separator
+            + "wso2mi" + File.separator + "resources";
 
     private Constants() {
     }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

Currently, only the connectors that are defined in the pom file are considered when resolving dependencies from the descriptor file. This PR improves the process so that the imported connectors are also considered when resolving dependencies.

Resolves https://github.com/wso2/mi-vscode/issues/845