### PR TITLE
Add sourceDirectory config to car plugin

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -92,7 +92,7 @@ public class CARMojo extends AbstractMojo {
         String basedir = project.getBasedir().toString();
         archiveLocation = StringUtils.isEmpty(archiveLocation) ? basedir + File.separator +
                 Constants.DEFAULT_TARGET_FOLDER : archiveLocation;
-        if (sourceDirectory == null) {
+        if (StringUtils.isEmpty(sourceDirectory)) {
             sourceDirectory = basedir;
         }
         String artifactFolderPath = sourceDirectory + File.separator + Constants.ARTIFACTS_FOLDER_PATH;

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -68,6 +68,13 @@ public class CARMojo extends AbstractMojo {
      */
     String archiveName;
 
+    /**
+     * The source directory
+     *
+     * @parameter expression="${sourceDirectory}"
+     */
+    private String sourceDirectory;
+
     public void logError(String message) {
         getLog().error(message);
     }
@@ -85,12 +92,15 @@ public class CARMojo extends AbstractMojo {
         String basedir = project.getBasedir().toString();
         archiveLocation = StringUtils.isEmpty(archiveLocation) ? basedir + File.separator +
                 Constants.DEFAULT_TARGET_FOLDER : archiveLocation;
-        String artifactFolderPath = basedir + File.separator + Constants.ARTIFACTS_FOLDER_PATH;
-        String resourcesFolderPath = basedir + File.separator + Constants.RESOURCES_FOLDER_PATH;
+        if (sourceDirectory == null) {
+            sourceDirectory = basedir;
+        }
+        String artifactFolderPath = sourceDirectory + File.separator + Constants.ARTIFACTS_FOLDER_PATH;
+        String resourcesFolderPath = sourceDirectory + File.separator + Constants.RESOURCES_FOLDER_PATH;
         DataMapperBundler bundler = null;
         try {
             try {
-                bundler = new DataMapperBundler(this, resourcesFolderPath, basedir);
+                bundler = new DataMapperBundler(this, basedir, sourceDirectory, resourcesFolderPath);
                 bundler.bundleDataMapper();
             } catch (DataMapperException e) {
                 getLog().error("Error during data mapper bundling: " + e.getMessage(), e);

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/datamapper/DataMapperBundler.java
@@ -53,12 +53,15 @@ import static org.wso2.maven.MavenUtils.setupInvoker;
 
 public class DataMapperBundler {
     private final CARMojo mojoInstance;
+    private final String sourceDirectory;
     private final String resourcesDirectory;
     private final String projectDirectory;
     private final Invoker invoker;
 
-    public DataMapperBundler(CARMojo mojoInstance, String resourcesDirectory, String projectDirectory) {
+    public DataMapperBundler(CARMojo mojoInstance, String projectDirectory, String sourceDirectory,
+                             String resourcesDirectory) {
         this.mojoInstance = mojoInstance;
+        this.sourceDirectory = sourceDirectory;
         this.resourcesDirectory = resourcesDirectory;
         this.projectDirectory = projectDirectory;
         this.invoker = new DefaultInvoker();
@@ -201,7 +204,7 @@ public class DataMapperBundler {
     private void generateDataMapperSchemas(List<Path> dataMappers) throws DataMapperException {
         createConfigJsonForSchemaGeneration();
         for (Path dataMapper : dataMappers) {
-            generateDataMapperSchema(dataMapper);
+            generateDataMapperSchema(dataMapper.toAbsolutePath());
         }
     }
 
@@ -761,6 +764,9 @@ public class DataMapperBundler {
      */
     private void deleteRecursively(File file, String excludeRegex) {
 
+        if (isInsideSourceDirectory(file)) {
+            return;
+        }
         if (file.isDirectory()) {
             File[] entries = file.listFiles();
             if (entries != null) {
@@ -774,5 +780,12 @@ public class DataMapperBundler {
                 mojoInstance.logError("Failed to delete " + file.getPath());
             }
         }
+    }
+
+    private boolean isInsideSourceDirectory(File file) {
+        Path sourcePath = Paths.get(sourceDirectory).toAbsolutePath().normalize();
+        Path filePath = file.toPath().toAbsolutePath().normalize();
+
+        return filePath.startsWith(sourcePath);
     }
 }


### PR DESCRIPTION
This PR adds a new configuration option to the CAR plugin, allowing users to specify a different source directory for retrieving artifacts to pack. This is useful in scenarios where artifacts need to be copied and preprocessed before packaging. The new source directory can be provided as an input to the CAR plugin to use during the packing process.

```
<plugin>
	<groupId>org.wso2.maven</groupId>
	<artifactId>vscode-car-plugin</artifactId>
	<version>${car.plugin.version}</version>
	<extensions>true</extensions>
	<executions>
		<execution>
			<phase>compile</phase>
			<goals>
				<goal>car</goal>
			</goals>
			<configuration>
				<sourceDirectory>./target/Test1</sourceDirectory>
			</configuration>
		</execution>
	</executions>
</plugin>
```

Relates to: https://github.com/wso2/mi-vscode/issues/628