### PR TITLE
Fix metadata file name issue

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -569,7 +569,7 @@ class CAppHandler extends AbstractXMLDoc {
             } else {
                 if (isProxy) {
                     name = name + Constants.PROXY_WITH_UNDERSCORE;
-                } else {
+                } else if (isDataService) {
                     name = name + Constants.DATA_SERVICE_WITH_UNDERSCORE;
                 }
                 artifactName = name + "_metadata";


### PR DESCRIPTION
## Purpose
Fix the following error when creating the metadata for API
```
 Some dependencies were not satisfied in cApp:test_mi_123_1.0.0Check whether all dependent artifacts are included in cApp file: /Users/wso2/Documents/maven-tool/fresh_Pack/wso2mi-4.4.0/tmp/carbonapps/-1234/1745384875818test_mi_123_1.0.0.car/
```
