### PR TITLE
Add support to work with custom inbound-connectors

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -142,7 +142,7 @@ public class CARMojo extends AbstractMojo {
             cAppHandler.processArtifacts(artifactFolder, tempTargetDir, dependencies, metaDependencies, projectVersion);
             cAppHandler.processAPIDefinitions(resourcesFolder, tempTargetDir, metaDependencies, projectVersion);
             cAppHandler.processResourcesFolder(resourcesFolder, tempTargetDir, dependencies,
-                    metaDependencies, projectVersion);
+                    metaDependencies, projectVersion, project);
             cAppHandler.processClassMediators(dependencies, project);
             resolveConnectorDependencies();
             cAppHandler.processConnectorLibDependencies(dependencies, project);

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -113,6 +113,8 @@ public class Constants {
     public static final String PACKAGE = "package";
     public static final String CONNECTOR = "connector";
     public static final String CONNECTORS_DIR_NAME = "connectors";
+    public static final String INBOUND_CONNECTORS_DIR_NAME = "inbound-connectors";
+    public static final String INBOUND_CONNECTORS_PREFIX = "mi-inbound-";
     public static final String CONNECTION_TYPE = "connectionType";
     public static final String PROJECT_RUNTIME_VERSION = "project.runtime.version";
     public static final String RUNTIME_VERSION_440 = "4.4.0";

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/MavenUtils.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/MavenUtils.java
@@ -108,7 +108,7 @@ public class MavenUtils {
      * @param project Maven project
      * @return whether to pack connector dependencies or not
      */
-    public static boolean ignoreConnectorDependencies(MavenProject project) {
+    public static boolean isConnectorPackingSupported(MavenProject project) {
         String runtimeVersion = project.getProperties().getProperty(Constants.PROJECT_RUNTIME_VERSION);
 
         if (runtimeVersion != null) {
@@ -116,7 +116,7 @@ public class MavenUtils {
             ComparableVersion currentVersion = new ComparableVersion(runtimeVersion);
             ComparableVersion targetVersion = new ComparableVersion(Constants.RUNTIME_VERSION_440);
 
-            return currentVersion.compareTo(targetVersion) < 0;
+            return currentVersion.compareTo(targetVersion) > 0;
         }
         return true;
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -77,13 +77,16 @@ public class ConnectorDependencyResolver {
         // Resolve connector ZIP files from pom.xml
         ArrayList<File> connectorZips = resolveConnectorZips(invoker);
 
-        if (MavenUtils.ignoreConnectorDependencies(project)) {
+        if (!MavenUtils.isConnectorPackingSupported(project)) {
             // runtime version is not 4.4.0 or higher, skip resolving dependencies
             return;
         }
 
         // Resolve connectors from resources folder
-        resolveConnectorZipsFromResources(connectorZips);
+        List<String> directories = Arrays.asList(Constants.CONNECTORS_DIR_NAME, Constants.INBOUND_CONNECTORS_DIR_NAME);
+        for (String directoryName : directories) {
+            resolveConnectorZipsFromResources(connectorZips, directoryName);
+        }
 
         Map<QName, File> dependencyFiles = new HashMap<>();
         // Extract all connector ZIP files
@@ -141,9 +144,9 @@ public class ConnectorDependencyResolver {
         return connectorZips;
     }
 
-    private static void resolveConnectorZipsFromResources(ArrayList<File> connectorZips) {
+    private static void resolveConnectorZipsFromResources(ArrayList<File> connectorZips, String directoryName) {
 
-        File connectorsDir = new File(Constants.RESOURCES_FOLDER_PATH, Constants.CONNECTORS_DIR_NAME);
+        File connectorsDir = new File(Constants.RESOURCES_FOLDER_PATH, directoryName);
         if (!connectorsDir.exists()) {
             return;
         }


### PR DESCRIPTION
This PR will enable support to work with custom inbound connectors by packing them in the CAPP build process when the project runtime is MI 4.4.0 or above.

Related issue: https://github.com/wso2/mi-vscode/issues/1049