### PR TITLE
Skip javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,14 @@
             </extension>
         </extensions>
         <plugins>
+            <!-- TODO: migrate all legacy Javadoc-based plugin configuration to annotations and remove this. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>


### PR DESCRIPTION
The Maven plugins in this project currently use legacy Javadoc-based plugin configuration (e.g., `@goal`, `@phase`, `@parameter`). These tags are deprecated and cause errors when the maven-javadoc-plugin runs under Java 11 or newer, due to stricter validation of Javadoc tags.
While the long-term fix is to migrate all plugin metadata to annotation-based configuration (e.g., `@Mojo`, `@Parameter`, `@Component`), this PR provides a temporary workaround by skipping the Javadoc generation during the build.

Related Issue: https://github.com/wso2/maven-tools/issues/193