### PR TITLE
Add deploymentType and update fat CAR bundling

### DIFF
--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -799,14 +799,11 @@ public class CAppHandler extends AbstractXMLDoc {
     public void createDependencyDescriptorFile(String archiveDirectory, MavenProject project) {
 
         String projectIdentifier = generateProjectIdentifier(project.getGroupId(), project.getArtifactId(), project.getVersion());
+        String deploymentType = project.getProperties().getProperty(Constants.DEPLOYMENT_TYPE, "");
         OMElement projectElement;
         boolean fatCarEnabled = CAppDependencyResolver.isFatCarEnabled(project);
-        if (!fatCarEnabled) {
-            List<CAppDependency> cAppDependencies = getTopLevelCAppDependencies(project);
-            projectElement = createDependencyDescriptorXml(projectIdentifier, cAppDependencies);
-        } else {
-            projectElement = createDependencyDescriptorXml(projectIdentifier);
-        }
+        List<CAppDependency> cAppDependencies = getTopLevelCAppDependencies(project);
+        projectElement = createDependencyDescriptorXml(projectIdentifier, deploymentType, cAppDependencies, fatCarEnabled);
         try {
             String descriptorXmlFileDataAsString = serialize(projectElement);
             org.wso2.developerstudio.eclipse.utils.file.FileUtils.createFile(
@@ -827,26 +824,28 @@ public class CAppHandler extends AbstractXMLDoc {
      */
     private String generateProjectIdentifier(String groupId, String artifactId, String version) {
 
-        return groupId + Constants.UNDERSCORE + artifactId + Constants.UNDERSCORE + version;
-    }
-
-    OMElement createDependencyDescriptorXml(String projectName) {
-
-        return createDependencyDescriptorXml(projectName, Collections.<CAppDependency>emptyList());
+        return groupId + Constants.DOUBLE_UNDERSCORE + artifactId + Constants.DOUBLE_UNDERSCORE + version;
     }
 
     /**
      * Creates the dependency descriptor XML element for the given project and its CApp dependencies.
      *
      * @param projectName      the name of the project
+     * @param deploymentType   the deployment type of the project
      * @param cAppDependencies the list of CApp dependencies
      * @return OMElement representing the dependency descriptor XML
      */
-    OMElement createDependencyDescriptorXml(String projectName, List<CAppDependency> cAppDependencies) {
+    OMElement createDependencyDescriptorXml(String projectName, String deploymentType,
+                                            List<CAppDependency> cAppDependencies, boolean fatCarEnabled) {
 
         OMElement projectElement = getElement(Constants.PROJECT, Constants.EMPTY_STRING);
         OMElement idElement = getElement(Constants.ID, projectName);
         projectElement.addChild(idElement);
+        OMElement deploymentTypeElement = getElement(Constants.DEPLOYMENT_TYPE, deploymentType);
+        projectElement.addChild(deploymentTypeElement);
+
+        OMElement fatCarEnabledElement = getElement(Constants.FAT_CAR_ENABLED, fatCarEnabled ? "true" : "false");
+        projectElement.addChild(fatCarEnabledElement);
 
         OMElement dependenciesElement = getElement(Constants.DEPENDENCIES, Constants.EMPTY_STRING);
         for (CAppDependency cAppDependency : cAppDependencies) {

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -135,13 +135,15 @@ public class Constants {
     public static final String CONFIG_DIR_PREFIX = "config_";
     public static final String METADATA_DIR = "metadata";
     public static final String HYPHEN = "-";
-    public static final String UNDERSCORE = "_";
+    public static final String DOUBLE_UNDERSCORE = "__";
     public static final String COLON = ":";
     public static final Character DOT_CHAR = '.';
     public static final String USER_HOME = "user.home";
     public static final String REPOSITORY = "repository";
     public static final String M2 = ".m2";
     public static final String LOCAL_MVN_SETTING = "MI.useLocalMaven";
+    public static final String DEPLOYMENT_TYPE = "deploymentType";
+    public static final String FAT_CAR_ENABLED = "fatCarEnabled";
 
     private Constants() {
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/CAppDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/CAppDependencyResolver.java
@@ -55,7 +55,6 @@ import java.util.zip.ZipInputStream;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import static org.apache.commons.io.FileUtils.copyDirectory;
 import static org.apache.commons.io.FileUtils.copyFile;
 import static org.wso2.maven.MavenUtils.createPomFile;
 import static org.wso2.maven.MavenUtils.setupInvoker;
@@ -85,40 +84,9 @@ public class CAppDependencyResolver {
         if (fatCarEnabled) {
             ArrayList<File> cAppFiles = getResolvedDependentCAppFiles(project.getBasedir(), dependenciesDir,
                     project.getArtifactId(), project.getVersion(), carMojo);
+            String dependencyDir = archiveDir + File.separator + Constants.DEPENDENCIES;
             for (File cappFile : cAppFiles) {
-                File extractDir =
-                        new File(cappFile.getParent(),
-                                cappFile.getName().replace(Constants.CAR_EXTENSION, StringUtils.EMPTY));
-                unzipFile(cappFile, extractDir);
-                // copy each dir in cApp to archiveDir
-                for (File file : Objects.requireNonNull(extractDir.listFiles())) {
-                    if (file.isDirectory()) {
-                        File targetDir = new File(archiveDir, file.getName());
-                        if (file.getName().startsWith(Constants.CONFIG_DIR_PREFIX)) {
-                            handleConfigPropertiesFile(file, targetDir);
-                        } else if (file.getName().equals(Constants.METADATA_DIR)) {
-                            for (File innerFile : Objects.requireNonNull(file.listFiles())) {
-                                File targetFile = new File(targetDir, innerFile.getName());
-                                if (innerFile.isDirectory()) {
-                                    copyDirectory(innerFile, targetFile);
-                                } else {
-                                    copyFile(innerFile, targetFile);
-                                }
-                            }
-                        } else {
-                            if (targetDir.exists()) {
-                                carMojo.logWarn("An artifact for: " + file.getName() +
-                                        " already exists in between dependencies or between a dependency and your project.");
-                            } else {
-                                copyDirectory(file, targetDir);
-                            }
-                        }
-                    }
-                }
-                updateArtifactDependencies(new File(extractDir, Constants.ARTIFACTS_XML_FILE), dependencies,
-                        carMojo);
-                updateArtifactDependencies(new File(extractDir, Constants.METADATA_XML_FILE), metaDependencies,
-                        carMojo);
+                copyFile(cappFile, new File(dependencyDir, cappFile.getName()));
             }
         }
     }

--- a/vscode-car-plugin/src/test/java/org/wso2/maven/CAppHandlerTest.java
+++ b/vscode-car-plugin/src/test/java/org/wso2/maven/CAppHandlerTest.java
@@ -51,7 +51,7 @@ public class CAppHandlerTest {
         CARMojo mojo = new CAppHandlerTest.MockCARMojo();
         CAppHandler handler = new CAppHandler("test", mojo);
 
-        OMElement result = handler.createDependencyDescriptorXml(projectName, java.util.Collections.<CAppDependency>emptyList());
+        OMElement result = handler.createDependencyDescriptorXml(projectName,"", java.util.Collections.<CAppDependency>emptyList(), false);
 
         assertNotNull(result);
         assertEquals("project", result.getLocalName());
@@ -71,7 +71,7 @@ public class CAppHandlerTest {
         List<CAppDependency> deps = Arrays.asList(new CAppDependency("group1", "artifact1", "1.0.0"),
                 new CAppDependency("group2", "artifact2", "2.0.0"));
 
-        OMElement result = handler.createDependencyDescriptorXml(projectName, deps);
+        OMElement result = handler.createDependencyDescriptorXml(projectName, "", deps, false);
 
         OMElement dependenciesElement = result.getFirstChildWithName(new javax.xml.namespace.QName("dependencies"));
         assertNotNull(dependenciesElement);


### PR DESCRIPTION
## Purpose

Add deploymentType and update fat CAR bundling which is required for the versioning support for CApps. To deploy a CAR as a versioned CAR, the `deploymentType` property should be set to `versionedDeployment`.

**Sample pom.xml**

```xml
<properties>
    <projectType>integration-project</projectType>
    <uuid>89a66d63-549f-40e2-858c-93f084b0e5a0</uuid>
    ...
    <deploymentType>versionedDeployment</deploymentType>
  </properties>
```

## Related Issue

https://github.com/wso2/product-micro-integrator/issues/4298