### PR TITLE
Introduce support to override connector dependencies in descriptor.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ target
 *.iws
 *.ipr
 .idea
-
+.DS_Store

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CARMojo.java
@@ -35,6 +35,8 @@ import org.apache.commons.lang.StringUtils;
 import org.wso2.maven.datamapper.DataMapperBundler;
 import org.wso2.maven.datamapper.DataMapperException;
 import org.wso2.maven.libraries.CAppDependencyResolver;
+import org.wso2.maven.libraries.ConnectorConfig;
+import org.wso2.maven.libraries.ConnectorConfigReader;
 import org.wso2.maven.libraries.ConnectorDependencyResolver;
 import org.wso2.maven.model.ArchiveException;
 import org.wso2.maven.model.ArtifactDependency;
@@ -146,11 +148,12 @@ public class CARMojo extends AbstractMojo {
             String projectVersion = project.getVersion().replace("-SNAPSHOT", "");
             cAppHandler.processArtifacts(artifactFolder, tempTargetDir, dependencies, metaDependencies, projectVersion);
             cAppHandler.processAPIDefinitions(resourcesFolder, tempTargetDir, metaDependencies, projectVersion);
+            ConnectorConfig connectorConfig = ConnectorConfigReader.read(project.getBasedir().getAbsolutePath());
             cAppHandler.processResourcesFolder(resourcesFolder, tempTargetDir, dependencies,
-                    metaDependencies, projectVersion, project);
+                    metaDependencies, projectVersion, project, connectorConfig);
             cAppHandler.processClassMediators(dependencies, project);
             resolveConnectorDependencies();
-            cAppHandler.processConnectorLibDependencies(dependencies, project);
+            cAppHandler.processConnectorLibDependencies(dependencies, project, connectorConfig);
             resolveCAppDependencies(tempTargetDir, dependencies, metaDependencies);
             cAppHandler.createDependencyArtifactsXmlFile(tempTargetDir, dependencies, metaDependencies, project);
             cAppHandler.createDependencyDescriptorFile(tempTargetDir, project);

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -36,6 +36,10 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.wso2.maven.libraries.CAppDependencyResolver;
+import org.wso2.maven.libraries.ConnectorConfig;
+import org.wso2.maven.libraries.ConnectorConfigReader;
+import org.wso2.maven.libraries.ConnectorDependencyConfig;
+import org.wso2.maven.libraries.ConnectorDependencyResolver;
 import org.wso2.maven.model.Artifact;
 import org.wso2.maven.model.ArtifactDependency;
 import org.wso2.maven.model.ArtifactDetails;
@@ -205,9 +209,10 @@ public class CAppHandler extends AbstractXMLDoc {
             mojoInstance.logInfo("Could not find resources folder in " + resourcesFolder.getAbsolutePath());
             return;
         }
-        processConnectors(resourcesFolder, archiveDirectory, dependencies, Constants.CONNECTORS_DIR_NAME);
+        ConnectorConfig connectorConfig = ConnectorConfigReader.read(project.getBasedir().getAbsolutePath());
+        processConnectors(resourcesFolder, archiveDirectory, dependencies, Constants.CONNECTORS_DIR_NAME, connectorConfig);
         if (MavenUtils.isConnectorPackingSupported(project)) {
-            processConnectors(resourcesFolder, archiveDirectory, dependencies, Constants.INBOUND_CONNECTORS_DIR_NAME);
+            processConnectors(resourcesFolder, archiveDirectory, dependencies, Constants.INBOUND_CONNECTORS_DIR_NAME, connectorConfig);
         }
         processRegistryResources(resourcesFolder, archiveDirectory, dependencies);
         processRegistryResources(new File(resourcesFolder, Constants.REGISTRY_DIR_NAME), archiveDirectory, dependencies);
@@ -222,8 +227,15 @@ public class CAppHandler extends AbstractXMLDoc {
      * @param archiveDirectory path to archive directory
      * @param dependencies     list of dependencies to be added to artifacts.xml file
      */
-    void processConnectors(File resourcesFolder, String archiveDirectory, List<ArtifactDependency> dependencies, String dirName) {
+    void processConnectors(File resourcesFolder, String archiveDirectory, List<ArtifactDependency> dependencies,
+                           String dirName, ConnectorConfig connectorConfig) {
         mojoInstance.logInfo("Processing connectors in " + resourcesFolder.getAbsolutePath());
+
+        if (connectorConfig != null && Boolean.TRUE.equals(connectorConfig.getOmitAllConnectors())) {
+            mojoInstance.logInfo("connector-config.json: omitAllConnectors=true — skipping all connector packing.");
+            return;
+        }
+
         File connectorFolder = new File(resourcesFolder, dirName);
         if (!connectorFolder.exists()) {
             return;
@@ -239,11 +251,37 @@ public class CAppHandler extends AbstractXMLDoc {
                 String name = fileName.substring(0, lastIndex);
                 // remove .zip at the end
                 String version = fileName.substring(lastIndex + 1, fileName.length() - 4);
+
+                // Check per-connector omit flag
+                if (isConnectorOmitted(connectorConfig, name)) {
+                    mojoInstance.logInfo("connector-config.json: omit=true for connector " + name + " — skipping.");
+                    continue;
+                }
+
                 dependencies.add(new ArtifactDependency(name, version, Constants.SERVER_ROLE_EI, true));
                 writeArtifactAndFile(connector, archiveDirectory, name, Constants.CONNECTOR_TYPE,
                         Constants.SERVER_ROLE_EI, version, fileName, name + "_" + version);
             }
         }
+    }
+
+    /**
+     * Returns true if the given connector (by artifactId name) has omit=true in connector-config.json.
+     * Matches by exact key or by suffix (e.g. "mi-connector-file" matches "file").
+     */
+    private boolean isConnectorOmitted(ConnectorConfig connectorConfig, String connectorName) {
+        if (connectorConfig == null || connectorConfig.getConnectors() == null) {
+            return false;
+        }
+        for (Map.Entry<String, ConnectorDependencyConfig> entry : connectorConfig.getConnectors().entrySet()) {
+            String key = entry.getKey();
+            if (key.equals(connectorName) || key.endsWith("-" + connectorName)
+                    || connectorName.equals(key) || connectorName.endsWith("-" + key)) {
+                ConnectorDependencyConfig cfg = entry.getValue();
+                return cfg != null && Boolean.TRUE.equals(cfg.getOmit());
+            }
+        }
+        return false;
     }
 
     void processPropertyFile(File resourcesFolder, String archiveDirectory, String version,
@@ -959,6 +997,10 @@ public class CAppHandler extends AbstractXMLDoc {
      */
     void processConnectorLibDependencies(List<ArtifactDependency> dependencies, MavenProject project) {
 
+        ConnectorConfig connectorConfig = ConnectorConfigReader.read(project.getBasedir().getAbsolutePath());
+        boolean omitAllConnectors = connectorConfig != null
+                && Boolean.TRUE.equals(connectorConfig.getOmitAllConnectors());
+
         // process connector dependencies
         File connectorDepFolder = new File(Paths.get(project.getBasedir().toString(),
                 Constants.DEFAULT_TARGET_FOLDER, Constants.DEPENDENCY).toString());
@@ -977,6 +1019,12 @@ public class CAppHandler extends AbstractXMLDoc {
                         // remove .zip at the end
                         String version = fileName.substring(lastIndex + 1,
                                 fileName.length() - Constants.ZIP_EXTENSION.length());
+
+                        if (omitAllConnectors || isConnectorOmitted(connectorConfig, name)) {
+                            mojoInstance.logInfo("connector-config.json: skipping connector ZIP: " + fileName);
+                            continue;
+                        }
+
                         dependencies.add(new ArtifactDependency(name, version, Constants.SERVER_ROLE_EI, true));
                         writeArtifactAndFile(dependencyFile, project.getBasedir().toString() + File.separator +
                                 Constants.TEMP_TARGET_DIR_NAME, name, Constants.CONNECTOR_TYPE,

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -38,6 +38,7 @@ import org.apache.maven.project.MavenProject;
 import org.wso2.maven.libraries.CAppDependencyResolver;
 import org.wso2.maven.libraries.ConnectorConfig;
 import org.wso2.maven.libraries.ConnectorDependencyConfig;
+import org.wso2.maven.libraries.ConnectorDependencyResolver;
 import org.wso2.maven.model.Artifact;
 import org.wso2.maven.model.ArtifactDependency;
 import org.wso2.maven.model.ArtifactDetails;
@@ -233,7 +234,7 @@ public class CAppHandler extends AbstractXMLDoc {
                            String dirName, ConnectorConfig connectorConfig) {
         mojoInstance.logInfo("Processing connectors in " + resourcesFolder.getAbsolutePath());
 
-        if (connectorConfig != null && Boolean.TRUE.equals(connectorConfig.getOmitAllConnectors())) {
+        if (connectorConfig != null && connectorConfig.isOmitAllConnectors()) {
             mojoInstance.logInfo("connector-config.json: omitAllConnectors=true — skipping all connector packing.");
             return;
         }
@@ -249,10 +250,13 @@ public class CAppHandler extends AbstractXMLDoc {
         for (File connector : connectorFiles) {
             if (connector.isFile() && connector.getName().endsWith(".zip")) {
                 String fileName = connector.getName();
-                int lastIndex = fileName.lastIndexOf('-');
-                String name = fileName.substring(0, lastIndex);
-                // remove .zip at the end
-                String version = fileName.substring(lastIndex + 1, fileName.length() - 4);
+                String name = ConnectorDependencyResolver.extractArtifactIdFromZipName(fileName);
+                String version = fileName.substring(name.length() + 1,
+                        fileName.length() - Constants.ZIP_EXTENSION.length());
+                if (version.isEmpty()) {
+                    mojoInstance.logWarn("Skipping connector ZIP with non-standard name (no version): " + fileName);
+                    continue;
+                }
 
                 // Check per-connector omit flag
                 if (isConnectorOmitted(connectorConfig, name)) {
@@ -285,7 +289,7 @@ public class CAppHandler extends AbstractXMLDoc {
             return false;
         }
         ConnectorDependencyConfig cfg = connectorConfig.getConnectors().get(connectorName);
-        return cfg != null && Boolean.TRUE.equals(cfg.getOmit());
+        return cfg != null && cfg.isOmit();
     }
 
     void processPropertyFile(File resourcesFolder, String archiveDirectory, String version,
@@ -1004,7 +1008,7 @@ public class CAppHandler extends AbstractXMLDoc {
                                          ConnectorConfig connectorConfig) {
 
         boolean omitAllConnectors = connectorConfig != null
-                && Boolean.TRUE.equals(connectorConfig.getOmitAllConnectors());
+                && connectorConfig.isOmitAllConnectors();
 
         // process connector dependencies
         File connectorDepFolder = new File(Paths.get(project.getBasedir().toString(),
@@ -1019,11 +1023,13 @@ public class CAppHandler extends AbstractXMLDoc {
                             continue;
                         }
                         String fileName = dependencyFile.getName();
-                        int lastIndex = fileName.lastIndexOf('-');
-                        String name = fileName.substring(0, lastIndex);
-                        // remove .zip at the end
-                        String version = fileName.substring(lastIndex + 1,
+                        String name = ConnectorDependencyResolver.extractArtifactIdFromZipName(fileName);
+                        String version = fileName.substring(name.length() + 1,
                                 fileName.length() - Constants.ZIP_EXTENSION.length());
+                        if (version.isEmpty()) {
+                            mojoInstance.logWarn("Skipping connector ZIP with non-standard name (no version): " + fileName);
+                            continue;
+                        }
 
                         if (omitAllConnectors || isConnectorOmitted(connectorConfig, name)) {
                             mojoInstance.logInfo("connector-config.json: skipping connector ZIP: " + fileName);
@@ -1046,6 +1052,14 @@ public class CAppHandler extends AbstractXMLDoc {
         }
 
         // Process library dependencies of connectors
+        boolean omitAllDrivers = connectorConfig != null
+                && connectorConfig.isOmitAllDrivers();
+        if (omitAllConnectors || omitAllDrivers) {
+            mojoInstance.logInfo("connector-config.json: skipping driver JAR packaging ("
+                    + (omitAllConnectors ? "omitAllConnectors" : "omitAllDrivers") + "=true).");
+            return;
+        }
+
         File libFolder = new File(project.getBasedir(), Constants.DEFAULT_TARGET_FOLDER + File.separator + Constants.LIBS);
 
         if (!libFolder.exists()) {
@@ -1063,6 +1077,23 @@ public class CAppHandler extends AbstractXMLDoc {
             }
 
             String connectorName = connectorDir.getName();
+
+            // Skip JARs for connectors that are omitted from the CAR or have their drivers omitted
+            if (connectorConfig != null && connectorConfig.getConnectors() != null) {
+                ConnectorDependencyConfig connectorCfg = connectorConfig.getConnectors().get(connectorName);
+                if (connectorCfg != null) {
+                    if (connectorCfg.isOmit()) {
+                        mojoInstance.logInfo("connector-config.json: omit=true for connector "
+                                + connectorName + " — skipping driver JAR packaging.");
+                        continue;
+                    }
+                    if (connectorCfg.isOmitAllDrivers()) {
+                        mojoInstance.logInfo("connector-config.json: omitAllDrivers=true for connector "
+                                + connectorName + " — skipping driver JAR packaging.");
+                        continue;
+                    }
+                }
+            }
             File[] libFiles = connectorDir.listFiles(new FilenameFilter() {
                 @Override
                 public boolean accept(File dir, String name) {

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -37,9 +37,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.wso2.maven.libraries.CAppDependencyResolver;
 import org.wso2.maven.libraries.ConnectorConfig;
-import org.wso2.maven.libraries.ConnectorConfigReader;
 import org.wso2.maven.libraries.ConnectorDependencyConfig;
-import org.wso2.maven.libraries.ConnectorDependencyResolver;
 import org.wso2.maven.model.Artifact;
 import org.wso2.maven.model.ArtifactDependency;
 import org.wso2.maven.model.ArtifactDetails;
@@ -199,17 +197,21 @@ public class CAppHandler extends AbstractXMLDoc {
     /**
      * Method to process resources folder and create corresponding files in the archive directory.
      *
-     * @param resourcesFolder  path to resources folder
-     * @param archiveDirectory path to archive directory
-     * @param dependencies     list of dependencies to be added to artifacts.xml file
+     * @param resourcesFolder    path to resources folder
+     * @param archiveDirectory   path to archive directory
+     * @param dependencies       list of dependencies to be added to artifacts.xml file
+     * @param metadataDependencies list of metadata dependencies
+     * @param version            project version
+     * @param project            Maven project
+     * @param connectorConfig    parsed connector-config.json (may be null)
      */
     void processResourcesFolder(File resourcesFolder, String archiveDirectory, List<ArtifactDependency> dependencies,
-                                List<ArtifactDependency> metadataDependencies, String version, MavenProject project) {
+                                List<ArtifactDependency> metadataDependencies, String version, MavenProject project,
+                                ConnectorConfig connectorConfig) {
         if (!resourcesFolder.exists()) {
             mojoInstance.logInfo("Could not find resources folder in " + resourcesFolder.getAbsolutePath());
             return;
         }
-        ConnectorConfig connectorConfig = ConnectorConfigReader.read(project.getBasedir().getAbsolutePath());
         processConnectors(resourcesFolder, archiveDirectory, dependencies, Constants.CONNECTORS_DIR_NAME, connectorConfig);
         if (MavenUtils.isConnectorPackingSupported(project)) {
             processConnectors(resourcesFolder, archiveDirectory, dependencies, Constants.INBOUND_CONNECTORS_DIR_NAME, connectorConfig);
@@ -266,22 +268,24 @@ public class CAppHandler extends AbstractXMLDoc {
     }
 
     /**
-     * Returns true if the given connector (by artifactId name) has omit=true in connector-config.json.
-     * Matches by exact key or by suffix (e.g. "mi-connector-file" matches "file").
+     * Returns {@code true} if the given connector is marked with {@code "omit": true} in
+     * {@code connector-config.json}.
+     *
+     * <p>The {@code connectorName} argument is the connector ZIP filename with its version suffix
+     * stripped, which equals the connector's Maven artifactId
+     * (e.g. {@code "mi-connector-file"} for {@code mi-connector-file-1.0.0.zip}).
+     * Config keys must be the full Maven artifactId.
+     *
+     * @param connectorConfig parsed {@code connector-config.json} (may be {@code null})
+     * @param connectorName   the connector's full Maven artifactId (e.g. {@code "mi-connector-file"})
+     * @return {@code true} if a matching connector entry has {@code omit: true}; {@code false} otherwise
      */
     private boolean isConnectorOmitted(ConnectorConfig connectorConfig, String connectorName) {
         if (connectorConfig == null || connectorConfig.getConnectors() == null) {
             return false;
         }
-        for (Map.Entry<String, ConnectorDependencyConfig> entry : connectorConfig.getConnectors().entrySet()) {
-            String key = entry.getKey();
-            if (key.equals(connectorName) || key.endsWith("-" + connectorName)
-                    || connectorName.equals(key) || connectorName.endsWith("-" + key)) {
-                ConnectorDependencyConfig cfg = entry.getValue();
-                return cfg != null && Boolean.TRUE.equals(cfg.getOmit());
-            }
-        }
-        return false;
+        ConnectorDependencyConfig cfg = connectorConfig.getConnectors().get(connectorName);
+        return cfg != null && Boolean.TRUE.equals(cfg.getOmit());
     }
 
     void processPropertyFile(File resourcesFolder, String archiveDirectory, String version,
@@ -992,12 +996,13 @@ public class CAppHandler extends AbstractXMLDoc {
     /**
      * Method to process lib dependencies which are inside deployment/lib/ folder in the project and add to dependencies
      *
-     * @param dependencies list of dependencies to be added to artifacts.xml file
-     * @param project      VSCode maven project
+     * @param dependencies    list of dependencies to be added to artifacts.xml file
+     * @param project         VSCode maven project
+     * @param connectorConfig parsed connector-config.json (may be null)
      */
-    void processConnectorLibDependencies(List<ArtifactDependency> dependencies, MavenProject project) {
+    void processConnectorLibDependencies(List<ArtifactDependency> dependencies, MavenProject project,
+                                         ConnectorConfig connectorConfig) {
 
-        ConnectorConfig connectorConfig = ConnectorConfigReader.read(project.getBasedir().getAbsolutePath());
         boolean omitAllConnectors = connectorConfig != null
                 && Boolean.TRUE.equals(connectorConfig.getOmitAllConnectors());
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/CAppHandler.java
@@ -250,13 +250,13 @@ public class CAppHandler extends AbstractXMLDoc {
         for (File connector : connectorFiles) {
             if (connector.isFile() && connector.getName().endsWith(".zip")) {
                 String fileName = connector.getName();
+                String baseName = fileName.substring(0, fileName.length() - Constants.ZIP_EXTENSION.length());
                 String name = ConnectorDependencyResolver.extractArtifactIdFromZipName(fileName);
-                String version = fileName.substring(name.length() + 1,
-                        fileName.length() - Constants.ZIP_EXTENSION.length());
-                if (version.isEmpty()) {
+                if (name.equals(baseName)) {
                     mojoInstance.logWarn("Skipping connector ZIP with non-standard name (no version): " + fileName);
                     continue;
                 }
+                String version = baseName.substring(name.length() + 1);
 
                 // Check per-connector omit flag
                 if (isConnectorOmitted(connectorConfig, name)) {
@@ -290,6 +290,35 @@ public class CAppHandler extends AbstractXMLDoc {
         }
         ConnectorDependencyConfig cfg = connectorConfig.getConnectors().get(connectorName);
         return cfg != null && cfg.isOmit();
+    }
+
+    /**
+     * Looks up a connector's config entry by either a direct key match or by matching the stored
+     * {@code qname} field against the given name.
+     *
+     * <p>The lib subdirectory written by {@link ConnectorDependencyResolver} is named after the
+     * connector QName (e.g. {@code {org.wso2.connector}db}), while connector-config.json is keyed
+     * by Maven artifact ID (e.g. {@code mi-connector-db}). When the language server populates the
+     * {@code qname} field, this method bridges the gap.
+     *
+     * @param connectorConfig parsed connector-config.json
+     * @param nameOrQName     the name to look up — either an artifact ID or a QName string
+     * @return the matching entry, or {@code null} if none found
+     */
+    private ConnectorDependencyConfig findConnectorCfgByQNameOrKey(ConnectorConfig connectorConfig,
+                                                                    String nameOrQName) {
+        // Fast path: direct key match (artifact ID)
+        ConnectorDependencyConfig direct = connectorConfig.getConnectors().get(nameOrQName);
+        if (direct != null) {
+            return direct;
+        }
+        // QName match: iterate entries and compare the stored qname field
+        for (ConnectorDependencyConfig cfg : connectorConfig.getConnectors().values()) {
+            if (nameOrQName.equals(cfg.getQname())) {
+                return cfg;
+            }
+        }
+        return null;
     }
 
     void processPropertyFile(File resourcesFolder, String archiveDirectory, String version,
@@ -1023,13 +1052,13 @@ public class CAppHandler extends AbstractXMLDoc {
                             continue;
                         }
                         String fileName = dependencyFile.getName();
+                        String baseName = fileName.substring(0, fileName.length() - Constants.ZIP_EXTENSION.length());
                         String name = ConnectorDependencyResolver.extractArtifactIdFromZipName(fileName);
-                        String version = fileName.substring(name.length() + 1,
-                                fileName.length() - Constants.ZIP_EXTENSION.length());
-                        if (version.isEmpty()) {
+                        if (name.equals(baseName)) {
                             mojoInstance.logWarn("Skipping connector ZIP with non-standard name (no version): " + fileName);
                             continue;
                         }
+                        String version = baseName.substring(name.length() + 1);
 
                         if (omitAllConnectors || isConnectorOmitted(connectorConfig, name)) {
                             mojoInstance.logInfo("connector-config.json: skipping connector ZIP: " + fileName);
@@ -1080,7 +1109,8 @@ public class CAppHandler extends AbstractXMLDoc {
 
             // Skip JARs for connectors that are omitted from the CAR or have their drivers omitted
             if (connectorConfig != null && connectorConfig.getConnectors() != null) {
-                ConnectorDependencyConfig connectorCfg = connectorConfig.getConnectors().get(connectorName);
+                ConnectorDependencyConfig connectorCfg = findConnectorCfgByQNameOrKey(
+                        connectorConfig, connectorName);
                 if (connectorCfg != null) {
                     if (connectorCfg.isOmit()) {
                         mojoInstance.logInfo("connector-config.json: omit=true for connector "

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -147,7 +147,8 @@ public class Constants {
     public static final String VERSIONED_DEPLOYMENT = "versionedDeployment";
     public static final String FAT_CAR_ENABLED = "fatCarEnabled";
     public static final String CONNECTOR_CONFIG_FILE = "src" + File.separator + "main" + File.separator
-            + "wso2mi" + File.separator + "connector-config.json";
+            + "wso2mi" + File.separator + "resources" + File.separator + "connectors" + File.separator
+            + "connector-config.json";
 
     private Constants() {
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/Constants.java
@@ -146,6 +146,8 @@ public class Constants {
     public static final String LOCAL_MVN_SETTING = "MI.useLocalMaven";
     public static final String VERSIONED_DEPLOYMENT = "versionedDeployment";
     public static final String FAT_CAR_ENABLED = "fatCarEnabled";
+    public static final String CONNECTOR_CONFIG_FILE = "src" + File.separator + "main" + File.separator
+            + "wso2mi" + File.separator + "connector-config.json";
 
     private Constants() {
     }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/CAppDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/CAppDependencyResolver.java
@@ -1,19 +1,18 @@
 /*
- * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
  *
- * WSO2 LLC. licenses this file to you under the Apache License,
+ * WSO2 LLC licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.wso2.maven.libraries;

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/CAppDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/CAppDependencyResolver.java
@@ -1,18 +1,19 @@
 /*
- * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 LLC licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.maven.libraries;

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfig.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfig.java
@@ -20,7 +20,7 @@ package org.wso2.maven.libraries;
 import java.util.Map;
 
 /**
- * Root model for {@code src/main/wso2mi/connector-config.json}.
+ * Root model for {@code src/main/wso2mi/resources/connectors/connector-config.json}.
  * The {@code connectors} map is keyed by the connector Maven artifactId.
  */
 public class ConnectorConfig {

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfig.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.libraries;
+
+import java.util.Map;
+
+/**
+ * Root model for {@code src/main/wso2mi/connector-config.json}.
+ * The {@code connectors} map is keyed by the connector Maven artifactId.
+ */
+public class ConnectorConfig {
+
+    private String version;
+
+    /**
+     * When true, no driver JARs will be packed into the CAR for any connector.
+     * Overrides all per-connector and per-dependency settings.
+     */
+    private Boolean omitAllDrivers;
+
+    /**
+     * When true, no connector ZIPs will be packed into the CAR.
+     */
+    private Boolean omitAllConnectors;
+
+    /** Key: connector artifactId (e.g. "mi-connector-file"). */
+    private Map<String, ConnectorDependencyConfig> connectors;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Boolean getOmitAllDrivers() {
+        return omitAllDrivers;
+    }
+
+    public Boolean getOmitAllConnectors() {
+        return omitAllConnectors;
+    }
+
+    public Map<String, ConnectorDependencyConfig> getConnectors() {
+        return connectors;
+    }
+}

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfig.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfig.java
@@ -1,18 +1,19 @@
 /*
- * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 LLC licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.maven.libraries;
@@ -31,12 +32,12 @@ public class ConnectorConfig {
      * When true, no driver JARs will be packed into the CAR for any connector.
      * Overrides all per-connector and per-dependency settings.
      */
-    private Boolean omitAllDrivers;
+    private boolean omitAllDrivers;
 
     /**
      * When true, no connector ZIPs will be packed into the CAR.
      */
-    private Boolean omitAllConnectors;
+    private boolean omitAllConnectors;
 
     /** Key: connector artifactId (e.g. "mi-connector-file"). */
     private Map<String, ConnectorDependencyConfig> connectors;
@@ -45,11 +46,11 @@ public class ConnectorConfig {
         return version;
     }
 
-    public Boolean getOmitAllDrivers() {
+    public boolean isOmitAllDrivers() {
         return omitAllDrivers;
     }
 
-    public Boolean getOmitAllConnectors() {
+    public boolean isOmitAllConnectors() {
         return omitAllConnectors;
     }
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfigReader.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfigReader.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.libraries;
+
+import com.google.gson.Gson;
+import org.wso2.maven.Constants;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Reads and queries {@code connector-config.json} from the project source tree.
+ * <p>
+ * Expected location: {@code src/main/wso2mi/connector-config.json} relative to the project base directory.
+ */
+public class ConnectorConfigReader {
+
+    private static final Logger LOGGER = Logger.getLogger(ConnectorConfigReader.class.getName());
+
+    private ConnectorConfigReader() {
+    }
+
+    /**
+     * Reads and parses {@code connector-config.json} from the given project base directory.
+     *
+     * @param projectBasePath absolute path to the Maven project root (where pom.xml lives)
+     * @return parsed {@link ConnectorConfig}, or {@code null} if the file does not exist or cannot be parsed
+     */
+    public static ConnectorConfig read(String projectBasePath) {
+
+        File configFile = new File(projectBasePath, Constants.CONNECTOR_CONFIG_FILE);
+        if (!configFile.exists()) {
+            return null;
+        }
+        try (FileReader reader = new FileReader(configFile)) {
+            ConnectorConfig config = new Gson().fromJson(reader, ConnectorConfig.class);
+            LOGGER.log(Level.INFO, "Loaded connector-config.json from: " + configFile.getAbsolutePath());
+            return config;
+        } catch (IOException | RuntimeException e) {
+            LOGGER.log(Level.WARNING, "Failed to read connector-config.json: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Finds the best-matching {@link DependencyOverride} for the given dependency.
+     * <p>
+     * Matching priority:
+     * <ol>
+     *   <li>Match by {@code connectionType} if non-null and the override has a matching connectionType.</li>
+     *   <li>Match by {@code groupId + artifactId} if the override has no connectionType but coordinates match.</li>
+     * </ol>
+     *
+     * @param config             the parsed connector config (may be null)
+     * @param connectorArtifactId Maven artifactId of the connector ZIP (e.g. "mi-connector-file")
+     * @param connectionType     connectionType from descriptor.yml (may be null)
+     * @param groupId            dependency groupId from descriptor.yml
+     * @param artifactId         dependency artifactId from descriptor.yml
+     * @return the matching override, or {@code null} if none found
+     */
+    public static DependencyOverride findOverride(ConnectorConfig config, String connectorArtifactId,
+                                                  String connectionType, String groupId, String artifactId) {
+
+        if (config == null || config.getConnectors() == null) {
+            return null;
+        }
+        ConnectorDependencyConfig connectorCfg = config.getConnectors().get(connectorArtifactId);
+        if (connectorCfg == null) {
+            return null;
+        }
+        List<DependencyOverride> overrides = connectorCfg.getDependencies();
+        if (overrides == null || overrides.isEmpty()) {
+            return null;
+        }
+
+        // First pass: match by connectionType
+        if (connectionType != null) {
+            for (DependencyOverride override : overrides) {
+                if (connectionType.equalsIgnoreCase(override.getConnectionType())) {
+                    return override;
+                }
+            }
+        }
+
+        // Second pass: match by groupId + artifactId (for overrides without connectionType)
+        if (groupId != null && artifactId != null) {
+            for (DependencyOverride override : overrides) {
+                if (override.getConnectionType() == null
+                        && groupId.equals(override.getGroupId())
+                        && artifactId.equals(override.getArtifactId())) {
+                    return override;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfigReader.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfigReader.java
@@ -19,6 +19,7 @@
 package org.wso2.maven.libraries;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang.StringUtils;
 import org.wso2.maven.Constants;
 
 import java.io.File;
@@ -103,7 +104,7 @@ public class ConnectorConfigReader {
         }
 
         // Second pass: match by groupId + artifactId (for overrides without connectionType)
-        if (groupId != null && artifactId != null) {
+        if (StringUtils.isNotEmpty(groupId) && StringUtils.isNotEmpty(artifactId)) {
             for (DependencyOverride override : overrides) {
                 if (override.getConnectionType() == null
                         && groupId.equals(override.getGroupId())

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfigReader.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfigReader.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 /**
  * Reads and queries {@code connector-config.json} from the project source tree.
  * <p>
- * Expected location: {@code src/main/wso2mi/connector-config.json} relative to the project base directory.
+ * Expected location: {@code src/main/wso2mi/resources/connectors/connector-config.json} relative to the project base directory.
  */
 public class ConnectorConfigReader {
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfigReader.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorConfigReader.java
@@ -1,18 +1,19 @@
 /*
- * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 LLC licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.maven.libraries;

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyConfig.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyConfig.java
@@ -35,6 +35,13 @@ public class ConnectorDependencyConfig {
      */
     private boolean omitAllDrivers;
 
+    /**
+     * The connector's QName in {@code {package}name} form (e.g. {@code {org.wso2.connector}db}).
+     * Written by the language server. Used by the CAR plugin to match this config entry against
+     * the lib subdirectory whose name is derived from the connector QName.
+     */
+    private String qname;
+
     private List<DependencyOverride> dependencies;
 
     public boolean isOmit() {
@@ -43,6 +50,10 @@ public class ConnectorDependencyConfig {
 
     public boolean isOmitAllDrivers() {
         return omitAllDrivers;
+    }
+
+    public String getQname() {
+        return qname;
     }
 
     public List<DependencyOverride> getDependencies() {

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyConfig.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.libraries;
+
+import java.util.List;
+
+/**
+ * Holds the configuration for a single connector in connector-config.json.
+ */
+public class ConnectorDependencyConfig {
+
+    /**
+     * When true, this connector's ZIP will not be packed into the CAR.
+     */
+    private Boolean omit;
+
+    /**
+     * When true, no driver JARs for this connector will be packed into the CAR.
+     */
+    private Boolean omitAllDrivers;
+
+    private List<DependencyOverride> dependencies;
+
+    public Boolean getOmit() {
+        return omit;
+    }
+
+    public Boolean getOmitAllDrivers() {
+        return omitAllDrivers;
+    }
+
+    public List<DependencyOverride> getDependencies() {
+        return dependencies;
+    }
+}

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyConfig.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyConfig.java
@@ -1,18 +1,19 @@
 /*
- * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 LLC licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.maven.libraries;
@@ -27,20 +28,20 @@ public class ConnectorDependencyConfig {
     /**
      * When true, this connector's ZIP will not be packed into the CAR.
      */
-    private Boolean omit;
+    private boolean omit;
 
     /**
      * When true, no driver JARs for this connector will be packed into the CAR.
      */
-    private Boolean omitAllDrivers;
+    private boolean omitAllDrivers;
 
     private List<DependencyOverride> dependencies;
 
-    public Boolean getOmit() {
+    public boolean isOmit() {
         return omit;
     }
 
-    public Boolean getOmitAllDrivers() {
+    public boolean isOmitAllDrivers() {
         return omitAllDrivers;
     }
 

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -58,8 +58,11 @@ public class ConnectorDependencyResolver {
     private static Set<String> activeConnectionTypes;
     private static boolean scannedConnections = false;
 
-    /** Regex to extract the Maven artifactId from a versioned ZIP filename, e.g. "mi-connector-file-4.0.36". */
-    private static final Pattern ARTIFACT_ID_PATTERN = Pattern.compile("^(.+)-(\\d+(?:\\.\\d+)+)$");
+    /** Regex to extract the Maven artifactId from a versioned ZIP filename.
+     *  Matches release versions (e.g. "mi-connector-file-4.0.36") and qualified versions
+     *  (e.g. "mi-connector-smpp-2.0.0-SNAPSHOT", "mi-connector-file-4.0.36-beta1"). */
+    private static final Pattern ARTIFACT_ID_PATTERN =
+            Pattern.compile("^(.+)-(\\d+(?:\\.\\d+)+(?:-[A-Za-z0-9]+)*)$");
 
     /**
      * Resolves dependencies for connectors.
@@ -330,19 +333,19 @@ public class ConnectorDependencyResolver {
                     // Local JAR override — copy directly, skip Maven resolution entirely
                     if (!StringUtils.isBlank(override.getLocalPath())) {
                         File localJar = new File(override.getLocalPath());
-                        if (localJar.exists() && localJar.isFile()) {
-                            File targetDir = new File(libDir + File.separator + connectorQName);
-                            targetDir.mkdirs();
-                            File dest = new File(targetDir, localJar.getName());
-                            Files.copy(localJar.toPath(), dest.toPath(),
-                                    java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                            carMojo.logInfo("Copied local driver JAR per connector-config.json: "
-                                    + localJar.getAbsolutePath() + " → " + dest.getAbsolutePath());
-                        } else {
-                            carMojo.logError("connector-config.json localPath JAR not found: "
-                                    + override.getLocalPath() + " — skipping dependency "
-                                    + groupId + ":" + artifactId);
+                        if (!localJar.exists() || !localJar.isFile()) {
+                            throw new LibraryResolverException(
+                                    "connector-config.json specifies localPath for " + connectorArtifactId
+                                    + " / " + connectionType + " but the file does not exist: "
+                                    + override.getLocalPath());
                         }
+                        File targetDir = new File(libDir + File.separator + connectorQName);
+                        targetDir.mkdirs();
+                        File dest = new File(targetDir, localJar.getName());
+                        Files.copy(localJar.toPath(), dest.toPath(),
+                                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                        carMojo.logInfo("Copied local driver JAR per connector-config.json: "
+                                + localJar.getAbsolutePath() + " → " + dest.getAbsolutePath());
                         continue;
                     }
                     // Apply coordinate overrides; bypass the connectionType gating below since
@@ -465,6 +468,12 @@ public class ConnectorDependencyResolver {
             }
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
             Document doc = builder.parse(localEntry);
             Element root = doc.getDocumentElement();

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -54,8 +54,8 @@ import static org.wso2.maven.MavenUtils.setupInvoker;
  */
 public class ConnectorDependencyResolver {
 
-    // connectionTypeMap and flag to check if connections are scanned
-    private static Map<String, Map<String, String>> connectionTypeMap;
+    // active connectionTypes and flag to check if connections are scanned
+    private static Set<String> activeConnectionTypes;
     private static boolean scannedConnections = false;
 
     /** Regex to extract the Maven artifactId from a versioned ZIP filename, e.g. "mi-connector-file-4.0.36". */
@@ -327,6 +327,24 @@ public class ConnectorDependencyResolver {
                                 + " (connector: " + connectorArtifactId + ")");
                         continue;
                     }
+                    // Local JAR override — copy directly, skip Maven resolution entirely
+                    if (!StringUtils.isBlank(override.getLocalPath())) {
+                        File localJar = new File(override.getLocalPath());
+                        if (localJar.exists() && localJar.isFile()) {
+                            File targetDir = new File(libDir + File.separator + connectorQName);
+                            targetDir.mkdirs();
+                            File dest = new File(targetDir, localJar.getName());
+                            Files.copy(localJar.toPath(), dest.toPath(),
+                                    java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                            carMojo.logInfo("Copied local driver JAR per connector-config.json: "
+                                    + localJar.getAbsolutePath() + " → " + dest.getAbsolutePath());
+                        } else {
+                            carMojo.logError("connector-config.json localPath JAR not found: "
+                                    + override.getLocalPath() + " — skipping dependency "
+                                    + groupId + ":" + artifactId);
+                        }
+                        continue;
+                    }
                     // Apply coordinate overrides; bypass the connectionType gating below since
                     // the user has explicitly declared this dependency in connector-config.json.
                     if (!StringUtils.isBlank(override.getGroupId())) {
@@ -341,35 +359,19 @@ public class ConnectorDependencyResolver {
                     carMojo.logInfo("Applying connector-config.json override for connector "
                             + connectorArtifactId + ": " + groupId + ":" + artifactId + ":" + version);
                 } else if (connectionType != null) {
-                    // No explicit override — apply the existing connectionType-based gating logic.
-                    // scan local entries folder for connections if not already scanned
+                    // No explicit override — filter by whether the connectionType is active in local entries.
                     if (!scannedConnections) {
                         carMojo.logInfo("Scanning local entries folder for connections.");
-                        connectionTypeMap =
+                        activeConnectionTypes =
                                 scanLocalEntriesForConnections(Constants.LOCAL_ENTRIES_FOLDER_PATH, carMojo);
                         scannedConnections = true;
                     }
 
-                    // skip the dependency if connectionType is not used
-                    if (connectionTypeMap == null || !connectionTypeMap.containsKey(connectionType)) {
+                    if (activeConnectionTypes == null || !activeConnectionTypes.contains(connectionType)) {
                         carMojo.logInfo("Skipping dependency: " + groupId + ":" + artifactId + ":" + version
                                 + " as the connectionType: " + connectionType
                                 + " is not found in the local entries.");
                         continue;
-                    }
-                    Map<String, String> connectionDetails = connectionTypeMap.get(connectionType);
-                    if (connectionDetails.containsKey(Constants.GROUP_ID)
-                            && !StringUtils.isBlank(connectionDetails.get(Constants.GROUP_ID))
-                            && connectionDetails.containsKey(Constants.ARTIFACT_ID)
-                            && !StringUtils.isBlank(connectionDetails.get(Constants.ARTIFACT_ID))
-                            && connectionDetails.containsKey(Constants.VERSION)
-                            && !StringUtils.isBlank(connectionDetails.get(Constants.VERSION))) {
-                        carMojo.logInfo(
-                                "DB Connection not using default driver, replacing dependency information"
-                                        + " with user provided driver details.");
-                        groupId = connectionDetails.get(Constants.GROUP_ID);
-                        artifactId = connectionDetails.get(Constants.ARTIFACT_ID);
-                        version = connectionDetails.get(Constants.VERSION);
                     }
                 }
 
@@ -435,82 +437,57 @@ public class ConnectorDependencyResolver {
     }
 
     /**
-     * Scans the local entries folder for connections and returns a map of
-     * connection types.
+     * Scans the local entries folder and returns the set of connectionType values that are
+     * actively used (i.e. have a matching {@code *.init} element with a {@code connectionType} child).
      *
-     * @param carMojo The Mojo instance.
-     * @return The map of connection types.
-     * @throws Exception If an error occurs while scanning the local entries folder.
+     * @param folderPath path to the local-entries artifact folder
+     * @param carMojo    the Mojo instance (for logging)
+     * @return set of active connectionType strings (case-sensitive, as written in the XML)
      */
-    private static Map<String, Map<String, String>> scanLocalEntriesForConnections(String folderPath, CARMojo carMojo)
+    private static Set<String> scanLocalEntriesForConnections(String folderPath, CARMojo carMojo)
             throws Exception {
 
-        Map<String, Map<String, String>> connectionTypeMap = new HashMap<>();
+        Set<String> active = new HashSet<>();
 
         File localEntriesFolder = new File(folderPath);
         if (!localEntriesFolder.exists()) {
-            return connectionTypeMap;
+            return active;
         }
 
         File[] localEntries = localEntriesFolder.listFiles();
         if (localEntries == null) {
-            return connectionTypeMap;
+            return active;
         }
 
         for (File localEntry : localEntries) {
-            if (localEntry.isFile() && localEntry.getName().endsWith(".xml")) {
-                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-                factory.setNamespaceAware(true);
-                DocumentBuilder builder = factory.newDocumentBuilder();
-                Document doc = builder.parse(localEntry);
-                Element root = doc.getDocumentElement();
+            if (!localEntry.isFile() || !localEntry.getName().endsWith(".xml")) {
+                continue;
+            }
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            Document doc = builder.parse(localEntry);
+            Element root = doc.getDocumentElement();
 
-                String connectorName = "", connectionType = "";
-                NodeList initNodes = root.getElementsByTagName("*");
-                for (int i = 0; i < initNodes.getLength(); i++) {
-                    Element element = (Element) initNodes.item(i);
-                    String nodeName = element.getNodeName();
-                    if (nodeName.endsWith(".init")) {
-                        connectorName = nodeName.substring(0, nodeName.indexOf(".init"));
-                        NodeList ctNodes = element.getElementsByTagName("connectionType");
-                        if (ctNodes.getLength() > 0) {
-                            connectionType = ctNodes.item(0).getTextContent();
-                            Map<String, String> details = new HashMap<>();
-                            details.put(Constants.CONNECTOR_NAME, connectorName);
-                            // If DB, get Maven coordinates
-                            if (Constants.DB_CONNECTOR_NAME.equalsIgnoreCase(connectorName)) {
-                                carMojo.logInfo("Checking if connection has custom driver dependency.");
-                                String groupId = getFirstTagValue(root, Constants.GROUP_ID);
-                                String artifactId = getFirstTagValue(root, Constants.ARTIFACT_ID);
-                                String version = getFirstTagValue(root, Constants.VERSION);
-                                details.put(Constants.GROUP_ID, groupId);
-                                details.put(Constants.ARTIFACT_ID, artifactId);
-                                details.put(Constants.VERSION, version);
-                                    // If not in map, or new version is higher → update
-                                    if (!connectionTypeMap.containsKey(connectionType)
-                                            || (connectionTypeMap.get(connectionType).containsKey(Constants.VERSION) && isHigherVersion(details.get(Constants.VERSION),
-                                            connectionTypeMap.get(connectionType).get(Constants.VERSION)))) {
-                                        carMojo.logInfo(
-                                                "Adding custom driver dependency for Connection type: " +
-                                                        connectionType + " GroupID: " +
-                                                        details.get(Constants.GROUP_ID) +
-                                                        " ArtifactID: " + details.get(Constants.ARTIFACT_ID) +
-                                                        " Version: " + details.get(Constants.VERSION));
-                                        connectionTypeMap.put(connectionType, details);
-                                    }
-
-                            }
-                            break;
+            NodeList initNodes = root.getElementsByTagName("*");
+            for (int i = 0; i < initNodes.getLength(); i++) {
+                Element element = (Element) initNodes.item(i);
+                if (element.getNodeName().endsWith(".init")) {
+                    NodeList ctNodes = element.getElementsByTagName("connectionType");
+                    if (ctNodes.getLength() > 0) {
+                        String connectionType = ctNodes.item(0).getTextContent().trim();
+                        if (!connectionType.isEmpty()) {
+                            active.add(connectionType);
+                            carMojo.getLog().info("Found active connectionType: " + connectionType
+                                    + " in " + localEntry.getName());
                         }
                     }
+                    break;
                 }
-
-                carMojo.getLog().info("Found local entry file: " + localEntry.getPath() + " with connectionType: "
-                        + connectionType + " and connectorName: " + connectorName);
             }
         }
 
-        return connectionTypeMap;
+        return active;
     }
 
     public static QName extractConnectorInfo(CARMojo carMojo, String filePath) {
@@ -561,36 +538,4 @@ public class ConnectorDependencyResolver {
         return name;
     }
 
-    private static String getFirstTagValue(Element root, String tagName) {
-
-        NodeList nodes = root.getElementsByTagName(tagName);
-        return nodes.getLength() > 0 ? nodes.item(0).getTextContent().trim() : "";
-    }
-
-    private static boolean isHigherVersion(String newVersion, String currentVersion) {
-
-        if (newVersion == null || newVersion.isEmpty()) return false;
-        if (currentVersion == null || currentVersion.isEmpty()) return true;
-
-        String[] newParts = newVersion.split("\\.");
-        String[] currParts = currentVersion.split("\\.");
-        int len = Math.max(newParts.length, currParts.length);
-
-        for (int i = 0; i < len; i++) {
-            int n = i < newParts.length ? parseIntSafe(newParts[i]) : 0;
-            int c = i < currParts.length ? parseIntSafe(currParts[i]) : 0;
-            if (n > c) return true;
-            if (n < c) return false;
-        }
-        return false; // equal versions
-    }
-
-    private static int parseIntSafe(String s) {
-
-        try {
-            return Integer.parseInt(s);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
-    }
 }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -273,7 +273,13 @@ public class ConnectorDependencyResolver {
         }
 
         Yaml yaml = new Yaml();
-        Map<String, Object> yamlData = yaml.load(Files.newInputStream(descriptorYaml.toPath()));
+        Map<String, Object> yamlData;
+        try (InputStream is = Files.newInputStream(descriptorYaml.toPath())) {
+            yamlData = yaml.load(is);
+        } catch (IOException e) {
+            carMojo.logError("Failed to read descriptor.yml for connector " + connectorArtifactId + ": " + e.getMessage());
+            return;
+        }
 
         // Extract repositories
         List<Map<String, String>> repositories = (List<Map<String, String>>) yamlData.get(Constants.REPOSITORIES);

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -37,6 +37,8 @@ import org.yaml.snakeyaml.Yaml;
 import java.io.*;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -55,6 +57,9 @@ public class ConnectorDependencyResolver {
     // connectionTypeMap and flag to check if connections are scanned
     private static Map<String, Map<String, String>> connectionTypeMap;
     private static boolean scannedConnections = false;
+
+    /** Regex to extract the Maven artifactId from a versioned ZIP filename, e.g. "mi-connector-file-4.0.36". */
+    private static final Pattern ARTIFACT_ID_PATTERN = Pattern.compile("^(.+)-(\\d+(?:\\.\\d+)+)$");
 
     /**
      * Resolves dependencies for connectors.
@@ -90,12 +95,36 @@ public class ConnectorDependencyResolver {
             resolveConnectorZipsFromResources(connectorZips, directoryName);
         }
 
+        // Load connector-config.json once for this build
+        ConnectorConfig connectorConfig = ConnectorConfigReader.read(project.getBasedir().getAbsolutePath());
+        if (connectorConfig != null && connectorConfig.getConnectors() != null) {
+            carMojo.logInfo("connector-config.json loaded. Overrides defined for: "
+                    + connectorConfig.getConnectors().keySet());
+        }
+
+        // Root-level: skip all connector dependency resolution
+        if (connectorConfig != null && Boolean.TRUE.equals(connectorConfig.getOmitAllDrivers())) {
+            carMojo.logInfo("connector-config.json: omitAllDrivers=true — skipping all connector driver resolution.");
+            return;
+        }
+
+        // Extract all connector ZIP files; track QName → (descriptorFile, artifactId)
         Map<QName, File> dependencyFiles = new HashMap<>();
-        // Extract all connector ZIP files
+        Map<QName, String> connectorArtifactIds = new HashMap<>();
+
         for (File zipFile : connectorZips) {
             String targetExtractDir = extractedDir + File.separator + zipFile.getName().replace(".zip", "");
             if (new File(targetExtractDir).exists()) {
                 carMojo.logInfo("Connector already extracted: " + zipFile.getName());
+                // Still track the artifactId so overrides work on cached extractions
+                QName cachedQName = extractConnectorInfo(carMojo, targetExtractDir);
+                if (cachedQName != null) {
+                    connectorArtifactIds.put(cachedQName, extractArtifactIdFromZipName(zipFile.getName()));
+                    File descriptorYaml = new File(targetExtractDir + File.separator + Constants.DESCRIPTOR_YAML);
+                    if (descriptorYaml.exists()) {
+                        dependencyFiles.put(cachedQName, descriptorYaml);
+                    }
+                }
                 continue;
             }
             extractZipFile(zipFile, targetExtractDir);
@@ -104,6 +133,9 @@ public class ConnectorDependencyResolver {
                 carMojo.logError("Failed to extract connector information from " + zipFile.getName());
                 continue;
             }
+            String artifactId = extractArtifactIdFromZipName(zipFile.getName());
+            connectorArtifactIds.put(qualifiedConnectorName, artifactId);
+
             File descriptorYaml = new File(targetExtractDir + File.separator + Constants.DESCRIPTOR_YAML);
             if (descriptorYaml.exists()) {
                 carMojo.getLog().info("Found descriptor file: " + descriptorYaml.getPath());
@@ -114,8 +146,10 @@ public class ConnectorDependencyResolver {
         if (!dependencyFiles.isEmpty()) {
             for (Map.Entry<QName, File> entry : dependencyFiles.entrySet()) {
                 carMojo.logInfo("Resolving dependencies for " + entry.getKey());
-                resolveMavenDependencies(entry.getValue(), libDirPath, invoker, carMojo, entry.getKey().toString(),
-                        project.getBasedir());
+                String connectorArtifactId = connectorArtifactIds.getOrDefault(
+                        entry.getKey(), entry.getKey().getLocalPart());
+                resolveMavenDependencies(entry.getValue(), libDirPath, invoker, carMojo,
+                        entry.getKey().toString(), connectorArtifactId, project.getBasedir(), connectorConfig);
             }
         }
         carMojo.logInfo("All dependencies resolved and extracted successfully.");
@@ -207,20 +241,35 @@ public class ConnectorDependencyResolver {
     }
 
     /**
-     * Resolves Maven dependencies from a descriptor.yml file.
+     * Resolves Maven dependencies from a descriptor.yml file, applying any overrides from
+     * {@code connector-config.json}.
      *
-     * @param descriptorYaml The descriptor.yml file.
-     * @param libDir         The directory to copy the dependencies to.
-     * @param invoker        The Maven Invoker.
-     * @param carMojo        The Mojo instance.
-     * @param connectorName  The connector name.
+     * @param descriptorYaml      The descriptor.yml file.
+     * @param libDir              The directory to copy the dependencies to.
+     * @param invoker             The Maven Invoker.
+     * @param carMojo             The Mojo instance.
+     * @param connectorQName      The connector QName string (used as the lib subdirectory name).
+     * @param connectorArtifactId The connector Maven artifactId (used to look up overrides).
+     * @param projectDir          The project base directory.
+     * @param overrideConfig      Parsed connector-config.json (may be null).
      * @throws Exception If an error occurs while resolving dependencies.
      */
     private static void resolveMavenDependencies(File descriptorYaml, String libDir, Invoker invoker, CARMojo carMojo,
-                                                 String connectorName, File projectDir) throws Exception {
+                                                 String connectorQName, String connectorArtifactId,
+                                                 File projectDir, ConnectorConfig overrideConfig) throws Exception {
 
         if (!descriptorYaml.exists()) {
             return;
+        }
+
+        // Per-connector: check if this connector's drivers should be omitted
+        if (overrideConfig != null && overrideConfig.getConnectors() != null) {
+            ConnectorDependencyConfig connectorCfg = overrideConfig.getConnectors().get(connectorArtifactId);
+            if (connectorCfg != null && Boolean.TRUE.equals(connectorCfg.getOmitAllDrivers())) {
+                carMojo.logInfo("connector-config.json: omitAllDrivers=true for connector "
+                        + connectorArtifactId + " — skipping driver resolution.");
+                return;
+            }
         }
 
         Yaml yaml = new Yaml();
@@ -235,7 +284,7 @@ public class ConnectorDependencyResolver {
             }
         }
 
-        // Extract dependencies
+        // Extract dependencies, applying overrides from connector-config.json
         List<Map<String, String>> dependencies = (List<Map<String, String>>) yamlData.get(Constants.DEPENDENCIES);
         Set<String> dependencySet = new HashSet<>();
         if (dependencies != null) {
@@ -243,11 +292,34 @@ public class ConnectorDependencyResolver {
                 String groupId = dependency.get(Constants.GROUP_ID);
                 String artifactId = dependency.get(Constants.ARTIFACT_ID);
                 String version = dependency.get(Constants.VERSION);
+                String connectionType = dependency.get(Constants.CONNECTION_TYPE);
 
-                // check if connectionType is provided
-                if (dependency.containsKey(Constants.CONNECTION_TYPE)) {
-                    String connectionType = dependency.get(Constants.CONNECTION_TYPE);
+                // Check connector-config.json for an override for this dependency
+                DependencyOverride override = ConnectorConfigReader.findOverride(
+                        overrideConfig, connectorArtifactId, connectionType, groupId, artifactId);
 
+                if (override != null) {
+                    if (Boolean.TRUE.equals(override.getOmit())) {
+                        carMojo.logInfo("Omitting dependency per connector-config.json: "
+                                + groupId + ":" + artifactId + ":" + version
+                                + " (connector: " + connectorArtifactId + ")");
+                        continue;
+                    }
+                    // Apply coordinate overrides; bypass the connectionType gating below since
+                    // the user has explicitly declared this dependency in connector-config.json.
+                    if (!StringUtils.isBlank(override.getGroupId())) {
+                        groupId = override.getGroupId();
+                    }
+                    if (!StringUtils.isBlank(override.getArtifactId())) {
+                        artifactId = override.getArtifactId();
+                    }
+                    if (!StringUtils.isBlank(override.getVersion())) {
+                        version = override.getVersion();
+                    }
+                    carMojo.logInfo("Applying connector-config.json override for connector "
+                            + connectorArtifactId + ": " + groupId + ":" + artifactId + ":" + version);
+                } else if (connectionType != null) {
+                    // No explicit override — apply the existing connectionType-based gating logic.
                     // scan local entries folder for connections if not already scanned
                     if (!scannedConnections) {
                         carMojo.logInfo("Scanning local entries folder for connections.");
@@ -259,18 +331,23 @@ public class ConnectorDependencyResolver {
                     // skip the dependency if connectionType is not used
                     if (connectionTypeMap == null || !connectionTypeMap.containsKey(connectionType)) {
                         carMojo.logInfo("Skipping dependency: " + groupId + ":" + artifactId + ":" + version
-                                + " as the connectionType: " + connectionType + " is not found in the local entries.");
+                                + " as the connectionType: " + connectionType
+                                + " is not found in the local entries.");
                         continue;
                     }
-                    if (connectionTypeMap.get(connectionType).containsKey(Constants.GROUP_ID) && !(connectionTypeMap.get(connectionType).get(Constants.GROUP_ID).isBlank()) &&
-                            connectionTypeMap.get(connectionType).containsKey(Constants.ARTIFACT_ID) && !(connectionTypeMap.get(connectionType).get(Constants.ARTIFACT_ID).isBlank())
-                            && connectionTypeMap.get(connectionType).containsKey(Constants.VERSION) && !(connectionTypeMap.get(connectionType).get(Constants.VERSION).isBlank())) {
+                    Map<String, String> connectionDetails = connectionTypeMap.get(connectionType);
+                    if (connectionDetails.containsKey(Constants.GROUP_ID)
+                            && !StringUtils.isBlank(connectionDetails.get(Constants.GROUP_ID))
+                            && connectionDetails.containsKey(Constants.ARTIFACT_ID)
+                            && !StringUtils.isBlank(connectionDetails.get(Constants.ARTIFACT_ID))
+                            && connectionDetails.containsKey(Constants.VERSION)
+                            && !StringUtils.isBlank(connectionDetails.get(Constants.VERSION))) {
                         carMojo.logInfo(
-                                "DB Connection not using default driver, replacing dependency information with user provided driver details.");
-                        groupId = connectionTypeMap.get(connectionType).get(Constants.GROUP_ID);
-                        artifactId = connectionTypeMap.get(connectionType).get(Constants.ARTIFACT_ID);
-                        version = connectionTypeMap.get(connectionType).get(Constants.VERSION);
-
+                                "DB Connection not using default driver, replacing dependency information"
+                                        + " with user provided driver details.");
+                        groupId = connectionDetails.get(Constants.GROUP_ID);
+                        artifactId = connectionDetails.get(Constants.ARTIFACT_ID);
+                        version = connectionDetails.get(Constants.VERSION);
                     }
                 }
 
@@ -279,7 +356,7 @@ public class ConnectorDependencyResolver {
         }
 
         List<String> dependenciesList = new ArrayList<>(dependencySet);
-        resolveAndCopyDependencies(dependenciesList, repositoriesList, libDir, invoker, carMojo, connectorName,
+        resolveAndCopyDependencies(dependenciesList, repositoriesList, libDir, invoker, carMojo, connectorQName,
                 projectDir);
     }
 
@@ -439,6 +516,27 @@ public class ConnectorDependencyResolver {
             carMojo.logError("Error occurred while extracting connector information: " + e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Extracts the Maven artifactId from a connector ZIP filename by stripping the version suffix.
+     * <p>
+     * Example: {@code "mi-connector-file-4.0.36.zip"} → {@code "mi-connector-file"}.
+     * Falls back to the name-without-extension if the pattern does not match.
+     *
+     * @param zipFileName the ZIP filename (with or without the .zip extension)
+     * @return the artifactId portion of the filename
+     */
+    static String extractArtifactIdFromZipName(String zipFileName) {
+
+        String name = zipFileName.endsWith(Constants.ZIP_EXTENSION)
+                ? zipFileName.substring(0, zipFileName.length() - Constants.ZIP_EXTENSION.length())
+                : zipFileName;
+        Matcher matcher = ARTIFACT_ID_PATTERN.matcher(name);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+        return name;
     }
 
     private static String getFirstTagValue(Element root, String tagName) {

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/ConnectorDependencyResolver.java
@@ -103,8 +103,12 @@ public class ConnectorDependencyResolver {
         }
 
         // Root-level: skip all connector dependency resolution
-        if (connectorConfig != null && Boolean.TRUE.equals(connectorConfig.getOmitAllDrivers())) {
+        if (connectorConfig != null && connectorConfig.isOmitAllDrivers()) {
             carMojo.logInfo("connector-config.json: omitAllDrivers=true — skipping all connector driver resolution.");
+            return;
+        }
+        if (connectorConfig != null && connectorConfig.isOmitAllConnectors()) {
+            carMojo.logInfo("connector-config.json: omitAllConnectors=true — skipping all connector driver resolution.");
             return;
         }
 
@@ -145,9 +149,21 @@ public class ConnectorDependencyResolver {
 
         if (!dependencyFiles.isEmpty()) {
             for (Map.Entry<QName, File> entry : dependencyFiles.entrySet()) {
-                carMojo.logInfo("Resolving dependencies for " + entry.getKey());
                 String connectorArtifactId = connectorArtifactIds.getOrDefault(
                         entry.getKey(), entry.getKey().getLocalPart());
+
+                // Skip driver resolution for connectors that are themselves omitted from the CAR
+                if (connectorConfig != null && connectorConfig.getConnectors() != null) {
+                    ConnectorDependencyConfig connectorCfg =
+                            connectorConfig.getConnectors().get(connectorArtifactId);
+                    if (connectorCfg != null && connectorCfg.isOmit()) {
+                        carMojo.logInfo("connector-config.json: omit=true for connector "
+                                + connectorArtifactId + " — skipping driver resolution.");
+                        continue;
+                    }
+                }
+
+                carMojo.logInfo("Resolving dependencies for " + entry.getKey());
                 resolveMavenDependencies(entry.getValue(), libDirPath, invoker, carMojo,
                         entry.getKey().toString(), connectorArtifactId, project.getBasedir(), connectorConfig);
             }
@@ -265,7 +281,7 @@ public class ConnectorDependencyResolver {
         // Per-connector: check if this connector's drivers should be omitted
         if (overrideConfig != null && overrideConfig.getConnectors() != null) {
             ConnectorDependencyConfig connectorCfg = overrideConfig.getConnectors().get(connectorArtifactId);
-            if (connectorCfg != null && Boolean.TRUE.equals(connectorCfg.getOmitAllDrivers())) {
+            if (connectorCfg != null && connectorCfg.isOmitAllDrivers()) {
                 carMojo.logInfo("connector-config.json: omitAllDrivers=true for connector "
                         + connectorArtifactId + " — skipping driver resolution.");
                 return;
@@ -305,7 +321,7 @@ public class ConnectorDependencyResolver {
                         overrideConfig, connectorArtifactId, connectionType, groupId, artifactId);
 
                 if (override != null) {
-                    if (Boolean.TRUE.equals(override.getOmit())) {
+                    if (override.isOmit()) {
                         carMojo.logInfo("Omitting dependency per connector-config.json: "
                                 + groupId + ":" + artifactId + ":" + version
                                 + " (connector: " + connectorArtifactId + ")");
@@ -533,7 +549,7 @@ public class ConnectorDependencyResolver {
      * @param zipFileName the ZIP filename (with or without the .zip extension)
      * @return the artifactId portion of the filename
      */
-    static String extractArtifactIdFromZipName(String zipFileName) {
+    public static String extractArtifactIdFromZipName(String zipFileName) {
 
         String name = zipFileName.endsWith(Constants.ZIP_EXTENSION)
                 ? zipFileName.substring(0, zipFileName.length() - Constants.ZIP_EXTENSION.length())

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/DependencyOverride.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/DependencyOverride.java
@@ -1,18 +1,19 @@
 /*
- * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 LLC licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.maven.libraries;
@@ -42,7 +43,7 @@ public class DependencyOverride {
      * When true, this dependency is excluded from the CAR entirely.
      * Mutually exclusive with version/groupId/artifactId overrides.
      */
-    private Boolean omit;
+    private boolean omit;
 
     public String getConnectionType() {
         return connectionType;
@@ -60,7 +61,7 @@ public class DependencyOverride {
         return version;
     }
 
-    public Boolean getOmit() {
+    public boolean isOmit() {
         return omit;
     }
 }

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/DependencyOverride.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/DependencyOverride.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.libraries;
+
+/**
+ * Represents a single dependency override entry in connector-config.json.
+ * <p>
+ * A match is attempted first by {@code connectionType} (if present in the descriptor.yml
+ * dependency), then by {@code groupId + artifactId}. Any field left null falls through to
+ * the descriptor.yml default.
+ */
+public class DependencyOverride {
+
+    /** Matches the {@code connectionType} field in descriptor.yml. Optional. */
+    private String connectionType;
+
+    /** Override groupId. Null means keep the descriptor.yml default. */
+    private String groupId;
+
+    /** Override artifactId. Null means keep the descriptor.yml default. */
+    private String artifactId;
+
+    /** Override version. Null means keep the descriptor.yml default. */
+    private String version;
+
+    /**
+     * When true, this dependency is excluded from the CAR entirely.
+     * Mutually exclusive with version/groupId/artifactId overrides.
+     */
+    private Boolean omit;
+
+    public String getConnectionType() {
+        return connectionType;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Boolean getOmit() {
+        return omit;
+    }
+}

--- a/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/DependencyOverride.java
+++ b/vscode-car-plugin/src/main/java/org/wso2/maven/libraries/DependencyOverride.java
@@ -45,6 +45,12 @@ public class DependencyOverride {
      */
     private boolean omit;
 
+    /**
+     * Absolute path to a local JAR file. When set, Maven resolution is skipped and this JAR
+     * is copied directly into the CAR lib directory.
+     */
+    private String localPath;
+
     public String getConnectionType() {
         return connectionType;
     }
@@ -63,5 +69,9 @@ public class DependencyOverride {
 
     public boolean isOmit() {
         return omit;
+    }
+
+    public String getLocalPath() {
+        return localPath;
     }
 }

--- a/vscode-car-plugin/src/test/java/org/wso2/maven/libraries/ConnectorConfigReaderTest.java
+++ b/vscode-car-plugin/src/test/java/org/wso2/maven/libraries/ConnectorConfigReaderTest.java
@@ -1,18 +1,19 @@
 /*
- * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 LLC licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.maven.libraries;
@@ -72,7 +73,6 @@ public class ConnectorConfigReaderTest {
         assertEquals("MYSQL", override.getConnectionType());
         assertEquals("9.0.0", override.getVersion());
         assertNull(override.getGroupId());
-        assertNull(override.getOmit());
     }
 
     @Test
@@ -100,7 +100,7 @@ public class ConnectorConfigReaderTest {
         ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
         assertNotNull(config);
         DependencyOverride override = config.getConnectors().get("mi-connector-db").getDependencies().get(0);
-        assertEquals(Boolean.TRUE, override.getOmit());
+        assertTrue(override.isOmit());
     }
 
     // -------------------------------------------------------------------------

--- a/vscode-car-plugin/src/test/java/org/wso2/maven/libraries/ConnectorConfigReaderTest.java
+++ b/vscode-car-plugin/src/test/java/org/wso2/maven/libraries/ConnectorConfigReaderTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.maven.libraries;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectorConfigReaderTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    // -------------------------------------------------------------------------
+    // ConnectorConfigReader.read()
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRead_ReturnsNullWhenFileAbsent() {
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+        assertNull(config);
+    }
+
+    @Test
+    public void testRead_ParsesValidJson() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+
+        assertNotNull(config);
+        assertEquals("1.0", config.getVersion());
+        assertNotNull(config.getConnectors());
+        ConnectorDependencyConfig fileCfg = config.getConnectors().get("mi-connector-file");
+        assertNotNull(fileCfg);
+        assertEquals(1, fileCfg.getDependencies().size());
+        DependencyOverride override = fileCfg.getDependencies().get(0);
+        assertEquals("MYSQL", override.getConnectionType());
+        assertEquals("9.0.0", override.getVersion());
+        assertNull(override.getGroupId());
+        assertNull(override.getOmit());
+    }
+
+    @Test
+    public void testRead_ReturnsNullOnMalformedJson() throws IOException {
+        writeConfigFile("{ this is not valid json }");
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+        assertNull(config);
+    }
+
+    @Test
+    public void testRead_ParsesOmitTrue() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-db\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"ORACLE\", \"omit\": true }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+        assertNotNull(config);
+        DependencyOverride override = config.getConnectors().get("mi-connector-db").getDependencies().get(0);
+        assertEquals(Boolean.TRUE, override.getOmit());
+    }
+
+    // -------------------------------------------------------------------------
+    // ConnectorConfigReader.findOverride() — match by connectionType
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFindOverride_MatchByConnectionType() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+
+        DependencyOverride result = ConnectorConfigReader.findOverride(
+                config, "mi-connector-file", "MYSQL", "mysql", "mysql-connector-java");
+
+        assertNotNull(result);
+        assertEquals("9.0.0", result.getVersion());
+    }
+
+    @Test
+    public void testFindOverride_ConnectionTypeMatchIsCaseInsensitive() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MySQL\", \"version\": \"9.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+
+        DependencyOverride result = ConnectorConfigReader.findOverride(
+                config, "mi-connector-file", "MYSQL", null, null);
+
+        assertNotNull(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // ConnectorConfigReader.findOverride() — match by groupId + artifactId
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFindOverride_MatchByCoordinatesWhenNoConnectionType() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-http\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"groupId\": \"com.example\", \"artifactId\": \"my-lib\", \"version\": \"2.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+
+        // Descriptor dep has no connectionType; override matched by groupId+artifactId
+        DependencyOverride result = ConnectorConfigReader.findOverride(
+                config, "mi-connector-http", null, "com.example", "my-lib");
+
+        assertNotNull(result);
+        assertEquals("2.0.0", result.getVersion());
+    }
+
+    @Test
+    public void testFindOverride_ConnectionTypeTakesPriorityOverCoordinates() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" },\n" +
+                "        { \"groupId\": \"mysql\", \"artifactId\": \"mysql-connector-java\", \"version\": \"8.0.33\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+
+        // When connectionType matches, that entry is returned first
+        DependencyOverride result = ConnectorConfigReader.findOverride(
+                config, "mi-connector-file", "MYSQL", "mysql", "mysql-connector-java");
+
+        assertNotNull(result);
+        assertEquals("9.0.0", result.getVersion()); // connectionType match wins
+    }
+
+    // -------------------------------------------------------------------------
+    // ConnectorConfigReader.findOverride() — no match cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFindOverride_ReturnsNullForUnknownConnector() throws IOException {
+        writeConfigFile(
+                "{ \"version\": \"1.0\", \"connectors\": {} }"
+        );
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+
+        DependencyOverride result = ConnectorConfigReader.findOverride(
+                config, "mi-connector-unknown", "MYSQL", "mysql", "mysql-connector-java");
+
+        assertNull(result);
+    }
+
+    @Test
+    public void testFindOverride_ReturnsNullWhenConfigIsNull() {
+        assertNull(ConnectorConfigReader.findOverride(null, "mi-connector-file", "MYSQL", "g", "a"));
+    }
+
+    @Test
+    public void testFindOverride_ReturnsNullWhenConnectionTypeMismatch() throws IOException {
+        writeConfigFile(
+                "{\n" +
+                "  \"version\": \"1.0\",\n" +
+                "  \"connectors\": {\n" +
+                "    \"mi-connector-file\": {\n" +
+                "      \"dependencies\": [\n" +
+                "        { \"connectionType\": \"MYSQL\", \"version\": \"9.0.0\" }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}"
+        );
+        ConnectorConfig config = ConnectorConfigReader.read(tempFolder.getRoot().getAbsolutePath());
+
+        DependencyOverride result = ConnectorConfigReader.findOverride(
+                config, "mi-connector-file", "POSTGRES", null, null);
+
+        assertNull(result);
+    }
+
+    // -------------------------------------------------------------------------
+    // ConnectorDependencyResolver.extractArtifactIdFromZipName()
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testExtractArtifactId_StandardSemver() {
+        assertEquals("mi-connector-file",       ConnectorDependencyResolver.extractArtifactIdFromZipName("mi-connector-file-4.0.36.zip"));
+        assertEquals("mi-connector-amazonsqs",  ConnectorDependencyResolver.extractArtifactIdFromZipName("mi-connector-amazonsqs-2.0.2.zip"));
+        assertEquals("mi-connector-http",       ConnectorDependencyResolver.extractArtifactIdFromZipName("mi-connector-http-0.1.8.zip"));
+    }
+
+    @Test
+    public void testExtractArtifactId_WithoutZipExtension() {
+        assertEquals("mi-connector-file", ConnectorDependencyResolver.extractArtifactIdFromZipName("mi-connector-file-4.0.36"));
+    }
+
+    @Test
+    public void testExtractArtifactId_FallbackWhenNoVersionSuffix() {
+        // If no semver suffix, the full name is returned unchanged
+        String result = ConnectorDependencyResolver.extractArtifactIdFromZipName("custom-connector.zip");
+        assertEquals("custom-connector", result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private void writeConfigFile(String content) throws IOException {
+        File dir = new File(tempFolder.getRoot(), "src/main/wso2mi/resources/connectors");
+        dir.mkdirs();
+        try (FileWriter w = new FileWriter(new File(dir, "connector-config.json"))) {
+            w.write(content);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This improvement introduces a connector-config.json to store connector dependency overrides in the project level. 

Sample connector-config.json
```
{
  "version" : "1.0",
  "connectors" : {
    "mi-connector-db" : {
      "qname" : "{org.wso2.carbon.esb.connector}db",
      "dependencies" : [ {
        "connectionType" : "MICROSOFT_SQL_SERVER",
        "groupId" : "com.microsoft.sqlserver",
        "artifactId" : "mssql-jdbc",
        "version" : "13.4.0.jre11"
      }, {
        "connectionType" : "MYSQL",
        "groupId" : "com.mysql",
        "artifactId" : "mysql-connector-j",
        "version" : "",
        "localPath" : "/Users/wso2/mysql-connector-j-8.0.1.jar"
      } ]
    }
  }
}
```